### PR TITLE
Migrate generated schemas pages under static website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 services:
 - docker
 
+before_script:
+  - ./generate_schemas.sh
+
 script:
   - docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
   - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --disable-external

--- a/generate_schemas.sh
+++ b/generate_schemas.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+# Generate static schema pages from the ome-model specifications
+
+
+version=$(awk '/omemodel/{getline; print $0}' _config.yml | sed "s/  version: //")
+git clone git://github.com/ome/ome-model -b v$version
+(cd ome-model/specification && sh publish)
+mv ome-model/specification/target/published Schemas
+rm -rf ome-model


### PR DESCRIPTION
# Context

During the migration of the OME website 2 years ago, the [OME schemas](http://www.openmicroscopy.org/Schemas/) kept on the legacy server and [proxied to the new website](https://github.com/openmicroscopy/prod-playbooks/blob/master/www/www-deploy.yml#L30).

One of the main issue of the architecture above is any downtime of `www` or  `www-legacy` will cause schemas to be offline. The impact of such unavailability is the potential inability to validate any OME-TIFF file.
A second issue is the complexity of process for updating these pages either when releading new schemas, adding new representations of the OME specification (see https://github.com/ome/ome-model/issues/89) or simply updating the static HTML pages.

# Proposal

This PR adds a preliminary step to add the OME XSD schemas, XSLT transforms and landing pages to the source of  this repository. The website generated by Jekyll would already include all the Data Model schemas. Changes can be reviewed via GitHub pages part, schema pages would be part of the release assets and no proxying would be necessary in production.

Similar to #269, the main issue is to prevent specifications out-of-sync with the upstream specification defined in the ome-model repository. An inital attempt (827c8b80) checked out the schema pages under version control with a validation script. Following initial feedback, the sources for the schemas, transforms and schema landing pages are now generated in a pre-build step using the `generate_schemas.sh` script.

# Testing

With this PR included, http://snoopycrimecop.github.io/www.openmicroscopy.org/Schemas/ should now include the landing pages and schemas.

# Next steps

If the strategy proposed above is suitable and no alternate proposal comes up,:


- [ ] migrate the `publish` script to this repository
- [ ] fix `Schemas` vs `XMLSchemas`
- [ ] investigate some minimal unification with the OME CSS style
- [ ] migrate the [generated documentation](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome.html) under https://docs.openmicroscopy.org/
- [ ] deploy and remove the proxy

Outside the scope of this effort 

- [ ] improve the visibility and integration within the website (navigation)
- [ ] improve the generated landing pages