### PR TITLE
support: point "Forum" to image.sc

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -16,9 +16,9 @@ title: Support
                 <div class="card card-support">
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-comments-o fa-2x"></i>
-                        <h4>OME Forum</h4>
-                        <p class="card-caption">Our forums allow the whole community to share their expertise and solutions.</p>
-                        <a href="https://www.openmicroscopy.org/community/" target="_blank" class="btn-blue button small">Visit the Forum</a>
+                        <h4>Forum</h4>
+                        <p class="card-caption">The Scientific Community Image Forum allows the whole community to share their expertise and solutions.</p>
+                        <a href="https://forum.image.sc/tags/ome" target="_blank" class="btn-blue button small">Visit the Forum</a>
                     </div>
                 </div>
             </div>

--- a/support/index.html
+++ b/support/index.html
@@ -18,7 +18,7 @@ title: Support
                         <i class="border-red icon-red fa fa-comments-o fa-2x"></i>
                         <h4>Forum</h4>
                         <p class="card-caption">The Scientific Community Image Forum allows the whole community to share their expertise and solutions.</p>
-                        <a href="https://forum.image.sc/tags/ome" target="_blank" class="btn-blue button small">Visit the Forum</a>
+                        <a href="https://www.openmicroscopy.org/forums" target="_blank" class="btn-blue button small">Visit the Forum</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Currently using the somewhat empty "ome" tag. Alternatives include:

 - https://forum.image.sc/g/ome
 - https://forum.image.sc/g/ome/activity/posts
 - https://forum.image.sc/search? - with several or all tags like
   `expanded=true&q=tags%3Aomero%2Come%2Cbio-formats%2Come-tiff%2Come-xml`