### PR TITLE
Update support page with image.sc forum instead of old forums and lists

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -18,8 +18,11 @@ title: Support
                         <i class="border-red icon-red fa fa-comments-o fa-2x"></i>
                         <h4>Image.sc Forum</h4>
                         <p class="card-caption">
-                            Please use "ome", "omero" or "bio-formats" tags on the Image.sc Forum when posting or
-                            searching.
+                            Please use the
+                            <a href="https://image.sc/tags/ome">"ome"</a>,
+                            <a href="https://image.sc/tags/omero">"omero"</a> or
+                            <a href="https://image.sc/tags/bio-formats">"bio-formats"</>
+                            tags on the Image.sc Forum when posting or searching.
                           </p>
                         <a href="https://www.openmicroscopy.org/forums" target="_blank" class="btn-blue button small">Visit the Forum</a>
                     </div>

--- a/support/index.html
+++ b/support/index.html
@@ -16,41 +16,22 @@ title: Support
                 <div class="card card-support">
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-comments-o fa-2x"></i>
-                        <h4>Forum</h4>
-                        <p class="card-caption">The Scientific Community Image Forum allows the whole community to share their expertise and solutions.</p>
-                        <a href="https://www.openmicroscopy.org/forums" target="_blank" class="btn-blue button small">Visit the Forum</a>
+                        <h4>Image.sc Forum</h4>
+                        <p class="card-caption">
+                            Please use "ome", "omero" or "bio-formats" tags on the Image.sc Forum when posting or
+                            searching.
+                          </p>
+                        <a href="https://forum.image.sc/" target="_blank" class="btn-blue button small">Visit the Forum</a>
                     </div>
                 </div>
             </div>
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-blue icon-blue fa fa-life-ring fa-2x"></i>
+                        <i class="border-green icon-green fa fa-life-ring fa-2x"></i>
                         <h4>OMERO User Help</h4>
                         <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.</p>
                         <a href="https://help.openmicroscopy.org/" target="_blank" class="btn-blue button small">Get Help on OMERO</a>
-                    </div>
-                </div>
-            </div>
-            <div class="small-12 medium-4 columns">
-                <div class="card card-support">
-                    <div class="card-section">
-                        <i class="border-green icon-green fa fa-envelope-o fa-2x"></i>
-                        <h4>User Mailing List</h4>
-                        <p class="card-caption">Get support with installation and general use or make miscellaneous queries.</p>
-                        <a href="http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/" target="_blank" class="btn-blue button small">Subscribe to List</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="small-12 medium-4 columns">
-                <div class="card card-support">
-                    <div class="card-section">
-                        <i class="border-green icon-green fa fa-envelope-o fa-2x"></i>
-                        <h4>Developer Mailing List</h4>
-                        <p class="card-caption">Participate in developer discussions and get developer support.</p>
-                        <a href="http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/" target="_blank" class="btn-blue button small">Subscribe to List</a>
                     </div>
                 </div>
             </div>
@@ -64,18 +45,18 @@ title: Support
                     </div>
                 </div>
             </div>
+        </div>
+        <div class="row">
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-red icon-red fa fa-trello fa-2x"></i>
+                        <i class="border-green icon-green fa fa-trello fa-2x"></i>
                         <h4>Trello</h4>
                         <p class="card-caption">Keep track of development progress and give feedback on our topic-based boards.</p>
                         <a href="https://trello.com/b/4EXb35xQ/getting-started" target="_blank" class="btn-blue button small">Get Started</a>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="row">
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
@@ -95,9 +76,6 @@ title: Support
                         <a href="{{ site.baseurl }}/training/" class="btn-blue button small">Training Page</a>
                     </div>
                 </div>
-            </div>
-            <div class="small-12 medium-4 columns">
-                <!-- Placeholder to stop previous card floating right -->
             </div>
         </div>
         <!-- end Resources-->

--- a/support/index.html
+++ b/support/index.html
@@ -5,7 +5,7 @@ title: Support
         <div class="callout large primary" id="bg-image-support">
             <div class="row column text-center">
                 <h1>Support</h1>
-                <p>OME is committed to supporting our users and helping the community to help each other by providing the following resources. We also maintain both forums and mailing lists as support and discussion channels.</p>
+                <p>OME is committed to supporting our users and helping the community to help each other by providing the following resources.</p>
             </div>
         </div>
                 

--- a/support/index.html
+++ b/support/index.html
@@ -21,7 +21,7 @@ title: Support
                             Please use the
                             <a href="https://image.sc/tags/ome">"ome"</a>,
                             <a href="https://image.sc/tags/omero">"omero"</a> or
-                            <a href="https://image.sc/tags/bio-formats">"bio-formats"</>
+                            <a href="https://image.sc/tags/bio-formats">"bio-formats"</a>
                             tags on the Image.sc Forum when posting or searching.
                           </p>
                         <a href="https://www.openmicroscopy.org/forums" target="_blank" class="btn-blue button small">Visit the Forum</a>

--- a/support/index.html
+++ b/support/index.html
@@ -21,7 +21,7 @@ title: Support
                             Please use "ome", "omero" or "bio-formats" tags on the Image.sc Forum when posting or
                             searching.
                           </p>
-                        <a href="https://forum.image.sc/" target="_blank" class="btn-blue button small">Visit the Forum</a>
+                        <a href="https://www.openmicroscopy.org/forums" target="_blank" class="btn-blue button small">Visit the Forum</a>
                     </div>
                 </div>
             </div>

--- a/support/index.html
+++ b/support/index.html
@@ -33,7 +33,7 @@ title: Support
                     <div class="card-section">
                         <i class="border-green icon-green fa fa-life-ring fa-2x"></i>
                         <h4>OMERO User Help</h4>
-                        <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.<br/></p>
+                        <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.<br><br></p>
                         <a href="https://help.openmicroscopy.org/" target="_blank" class="btn-blue button small">Get Help on OMERO</a>
                     </div>
                 </div>
@@ -43,7 +43,7 @@ title: Support
                     <div class="card-section">
                         <i class="border-blue icon-blue fa fa-life-ring fa-2x"></i>
                         <h4>OMERO.qa</h4>
-                        <p class="card-caption">Submit files and bug reports for assistance from the developer team.</p>                        
+                        <p class="card-caption">Submit files and bug reports for assistance from the developer team.<br><br></p>                        
                         <a href="http://qa.openmicroscopy.org.uk" target="_blank" class="btn-blue button small">Visit the Site</a>                        
                     </div>
                 </div>
@@ -65,7 +65,7 @@ title: Support
                     <div class="card-section">
                         <i class="border-blue icon-blue fa fa-shield fa-2x" style="padding: 20px 25px;"></i>
                         <h4>SysAdmin Support</h4>
-                        <p class="card-caption">Get the latest on security advisories.</p>
+                        <p class="card-caption">Get the latest on security advisories.<br><br></p>
                         <a href="{{ site.baseurl }}/security/" class="btn-blue button small">View Advisories</a>
                     </div>
                 </div>

--- a/support/index.html
+++ b/support/index.html
@@ -33,7 +33,7 @@ title: Support
                     <div class="card-section">
                         <i class="border-green icon-green fa fa-life-ring fa-2x"></i>
                         <h4>OMERO User Help</h4>
-                        <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.</p>
+                        <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.<br/></p>
                         <a href="https://help.openmicroscopy.org/" target="_blank" class="btn-blue button small">Get Help on OMERO</a>
                     </div>
                 </div>


### PR DESCRIPTION
As requested by @pwalczysko (```#training channel 22:33```) - updated the support page with the image.sc forum instead of old forums and mailing lists.

Do we want to link to archives, or will they be ported soon enough?