### PR TITLE
Update all links to GS website

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
                 <div class="small-12 medium-4 columns">
                     <div class="medium-4"><a href="{{ site.baseurl }}/index.html"><img class="footer-logo" src="{{ site.baseurl }}/img/logos/ome-main-nav.svg" alt="OME logo" /></a></div>
                     <p>&copy; 2005-{{ site.time | date: "%Y" }} University of Dundee &amp; Open Microscopy Environment. <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">Creative Commons Attribution 4.0 International License</a></p>
-                    <p>OME source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or more permissive open source licenses, or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
+                    <p>OME source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or more permissive open source licenses, or through commercial license from <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
                     <p class="tiny-print" style="float:left;">[ <a href="{{ site.baseurl }}/site-map/">Site Map</a> ]</p>
                     <p class="tiny-print" style="float:right;">Version: {{ site.time | date: '%Y.%m.%d' }}</p>
                 </div>

--- a/bio-formats/index.html
+++ b/bio-formats/index.html
@@ -34,7 +34,7 @@ title: Bio-Formats
         </div>
         <hr>
         <div class="row column text-center">
-            <p>Bio-Formats is developed by the Open Microscopy Environment consortium, including development teams at <a href="https://loci.wisc.edu/" target="_blank">LOCI at the University of Wisconsin-Madison</a>, <a href="{{ site.baseurl }}/teams/index.html#swedlow-lab">University of Dundee</a> and <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>. Licensing and citing information is on the <a href="{{ site.baseurl }}/licensing/">OME licensing page</a>.</p>
+            <p>Bio-Formats is developed by the Open Microscopy Environment consortium, including development teams at <a href="https://loci.wisc.edu/" target="_blank">LOCI at the University of Wisconsin-Madison</a>, <a href="{{ site.baseurl }}/teams/index.html#swedlow-lab">University of Dundee</a> and <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a>. Licensing and citing information is on the <a href="{{ site.baseurl }}/licensing/">OME licensing page</a>.</p>
         </div>
         <!-- end -->
         

--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -53,8 +53,8 @@ title: Commercial Partners
             <div class="medium-6 columns">
                 <div class="text-center"><img style="max-height: 80px;" alt ="Glencoe Software logo" src="{{ site.baseurl }}/img/logos/glencoe-software.svg"></div>
                 <hr class="invisible">
-                <p>Currently, there is a range of aforementioned activities between the OME project and the commercial entities listed below. If you are interested in becoming a commercial partner, please contact <a href="http://www.glencoesoftware.com/jason-swedlow.html" target="_blank">Jason Swedlow</a>, CEO of Glencoe Software.</p>                
-                <p>OME’s commercial arm, <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software. Inc.</a>, provides supported or customized versions of Bio-Formats and OMERO for use in commercial products. Glencoe Software has successfully built many customized versions of OMERO. See <a href="http://www.glencoesoftware.com/customers.html" target="_blank">Glencoe Software’s Customers</a> for more information.</p>
+                <p>Currently, there is a range of aforementioned activities between the OME project and the commercial entities listed below. If you are interested in becoming a commercial partner, please contact <a href="https://www.glencoesoftware.com/contact/" target="_blank">Jason Swedlow</a>, CEO of Glencoe Software.</p>                
+                <p>OME’s commercial arm, <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software. Inc.</a>, provides supported or customized versions of Bio-Formats and OMERO for use in commercial products. Glencoe Software has successfully built many customized versions of OMERO. See <a href="https://www.glencoesoftware.com/customers/" target="_blank">Glencoe Software’s Customers</a> for more information.</p>
             </div>
             <div class="medium-5 medium-offset-1 columns">
                 <h5>Commercial licenses of OME software</h5>

--- a/events/11th-annual-users-meeting-2016.html
+++ b/events/11th-annual-users-meeting-2016.html
@@ -243,7 +243,7 @@ main-blurb: The 11th Annual OME Users Meeting was held at the University of Dund
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 2</span> - @Scale: Interacting with your data in OMERO</li>
                     <li><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/CLI-Data-Interaction/#/" target="_blank">Interacting with your data in OMERO (CLI)</a> ( <i class="fa fa-file-video-o"></i><a href="https://downloads.openmicroscopy.org/presentations/2016/Users-Meeting/Workshops/CLI-Data-Interaction.mov" target="_blank"> Movie version</a>)</li>
-                    <li>Interacting with your data in OMERO @scale (Scripts, Jupyter) (<a href="http://glencoesoftware.com/webinars.html" target="_blank">Webinar</a>) (<a href="https://github.com/glencoesoftware/webinar-notebooks" target="_blank">Jupyter notebooks</a>)</li>
+                    <li>Interacting with your data in OMERO @scale (Scripts, Jupyter) (<a href="http://www.glencoesoftware.com/media/webinars/" target="_blank">Webinar</a>) (<a href="https://github.com/glencoesoftware/webinar-notebooks" target="_blank">Jupyter notebooks</a>)</li>
                 </ul>
                 <ul class="event-workshop">
                     <li class="event-workshop-title"><span class="event-workshop-room">Room 3</span> - OMERO.figure</li>

--- a/licensing/index.html
+++ b/licensing/index.html
@@ -16,7 +16,7 @@ title: Licensing
         </div>
         <hr>
         <div class="row column">
-            <p>All OME formats and software are freely available, and all OMERO and Bio-Formats source code is available under GNU public “copyleft” licenses or more permissive open source licenses, or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
+            <p>All OME formats and software are freely available, and all OMERO and Bio-Formats source code is available under GNU public “copyleft” licenses or more permissive open source licenses, or through commercial license from <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
             <p>For questions about the GNU license refer to the <a href="http://www.gnu.org/licenses/gpl-faq.html" target="_blank">Frequently Asked Questions about the GNU Licenses</a> page.</p>
             <p>Please <a href="{{ site.baseurl }}/citing-ome/">cite our work</a> in your own publications to help us secure grant funding for future development of OME products.</p>
         </div>
@@ -29,7 +29,7 @@ title: Licensing
         </div>
         <hr>
         <div class="row column">
-            <p>Under the terms of the <a href="http://www.gnu.org/copyleft/" target="_blank">GNU public "copyleft" license</a>, any software package linking to Bio-Formats, either directly or indirectly, cannot be distributed unless its source code is also made available under the terms of the GPL. Some components which provide reader and writer implementations for open file formats, are released under a more permissive <a href="https://github.com/openmicroscopy/bioformats/blob/master/components/formats-bsd/LICENSE.txt" target="_blank">BSD-2 license</a> which enables non-GPL third party software. For a complete list of which file formats are included in the BSD license, see the BSD column of the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/supported-formats.html" target="_blank">supported formats table</a>. Developers of non-GPL software wishing to leverage Bio-Formats components not covered by the BSD license may purchase a commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
+            <p>Under the terms of the <a href="http://www.gnu.org/copyleft/" target="_blank">GNU public "copyleft" license</a>, any software package linking to Bio-Formats, either directly or indirectly, cannot be distributed unless its source code is also made available under the terms of the GPL. Some components which provide reader and writer implementations for open file formats, are released under a more permissive <a href="https://github.com/openmicroscopy/bioformats/blob/master/components/formats-bsd/LICENSE.txt" target="_blank">BSD-2 license</a> which enables non-GPL third party software. For a complete list of which file formats are included in the BSD license, see the BSD column of the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/supported-formats.html" target="_blank">supported formats table</a>. Developers of non-GPL software wishing to leverage Bio-Formats components not covered by the BSD license may purchase a commercial license from <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
         </div>
         <!-- end -->
         

--- a/omero/developers/index.html
+++ b/omero/developers/index.html
@@ -31,7 +31,7 @@ usergroup: developers
             <div class="medium-1 medium-offset-2 columns"><img class="omero-feature thumbnail" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_open-source.svg"></div>
             <div class="omero-key-feature-container medium-3 columns">
                 <h4>Open Source</h4>
-                <p>All OMERO source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or through commercial license from <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
+                <p>All OMERO source code is available under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General public license</a> or through commercial license from <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a>.</p>
                 <a class="button hollow tiny" href="https://github.com/openmicroscopy" target="_blank">Find us on GitHub</a>
             </div>
             <div class="medium-1 columns"><img class="omero-feature thumbnail" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_public-api.svg"></div>

--- a/omero/institution/index.html
+++ b/omero/institution/index.html
@@ -27,7 +27,7 @@ usergroup: institutions
                     forums.
                 </p>
                 <p>We keep the community updated on any <a href="{{ site.baseurl }}/security/">security vulnerabilities</a> through our <a href="{{ site.baseurl }}/security/advisories">advisories</a> page.</p>
-                <p>Our commercial partners <a href="http://www.glencoesoftware.com" target="_blank">Glencoe Software</a> also offer tailored installations and support packages if needed.</p>
+                <p>Our commercial partners <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software</a> also offer tailored installations and support packages if needed.</p>
             </div>
         </div>
         <!-- end Why Use OMERO -->


### PR DESCRIPTION
While reviewing another page of the website, I realized that a subset of the links pointing to Glencoe Software website are currently broken. This PR:

- uses HTTPS everywhere for glencoesoftware.com
- reviews all broken URLs (webinars, customers, contact)

/cc @chris-allan 