### PR TITLE
Remove dropped FAIRsharing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OME website
 
-[![Build Status](https://travis-ci.org/openmicroscopy/www.openmicroscopy.org.svg?branch=master)](https://travis-ci.org/openmicroscopy/www.openmicroscopy.org)
+[![Build Status](https://travis-ci.org/ome/www.openmicroscopy.org.svg?branch=master)](https://travis-ci.org/ome/www.openmicroscopy.org)
 
 This repository contains the source code for the OME Website hosted at
 https://www.openmicroscopy.org.

--- a/about/index.html
+++ b/about/index.html
@@ -257,7 +257,6 @@ partnerships2:
             </div></div></a></div>
             <div class="column"><a target="_blank" href="https://fairsharing.org/collection/OME"><div class="card-consortium card"><div class="card-section">OME Collection</div></div></a></div>
             <div class="column"><a target="_blank" href="https://fairsharing.org/biodbcore-000778/"><div class="card-consortium card"><div class="card-section">Image Data Resource (IDR)</div></div></a></div>
-            <div class="column"><a target="_blank" href="https://fairsharing.org/biodbcore-000614/"><div class="card-consortium card"><div class="card-section">OMERO Database</div></div></a></div>
             <div class="column"><a target="_blank" href="https://fairsharing.org/bsg-s000107/"><div class="card-consortium card"><div class="card-section">OME-XML Format</div></div></a></div>
             <div class="column"><a target="_blank" href="https://fairsharing.org/bsg-s000537/"><div class="card-consortium card"><div class="card-section">OME-TIFF Format</div></div></a></div>
         </div>


### PR DESCRIPTION
The OMERO database has been removed as a record from the FAIRSharing and is now only listed as tool under IDR.

Staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/about/