### PR TITLE
Update banner to mention imminent OMERO 5.6.1 release.

### DIFF
--- a/_includes/navbar-sub-omero.html
+++ b/_includes/navbar-sub-omero.html
@@ -1,6 +1,6 @@
 <!-- begin banner announcement -->
 <section class="announcement">
-    <span><i class="fa fa-bullhorn"></i> IMPORTANT: End-of-life for all Python 2-based versions of OMERO - <a class="styled-link" href="{{ site.baseurl }}/2020/01/15/omero-5-6-0.html">Read the Announcement</a></span>
+    <span><i class="fa fa-bullhorn"></i> IMPORTANT: Critical security release of OMERO on March 25th - <a class="styled-link" href="https://forum.image.sc/t/34691">Read the Announcement</a></span>
 </section>
 <!-- end banner announcement -->
 

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -259,7 +259,7 @@ h3.subdivider {
 
 /* ========== hero background images / callouts ==========*/
 section.announcement {
-    background-color: #03a9f4;
+    background-color: #e00;
     color: #fff;
     font-size: 14px;
     font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ many_thanks:
 ---
         <!-- begin banner announcement -->
         <section class="announcement">
-            <span><i class="fa fa-bullhorn"></i> IMPORTANT: End-of-life for all Python 2-based versions of OMERO - <a class="styled-link" href="{{ site.baseurl }}/2020/01/15/omero-5-6-0.html">Read the Announcement</a></span>
+            <span><i class="fa fa-bullhorn"></i> IMPORTANT: Critical security release of OMERO on March 25th - <a class="styled-link" href="https://forum.image.sc/t/34691">Read the Announcement</a></span>
         </section>
         <!-- end banner announcement -->
 


### PR DESCRIPTION
On release can update banner to link to `{{ site.baseurl }}/2020/03/25/omero-5-6-1.html`.