### PR TITLE
Add brand colors to css

### DIFF
--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -89,6 +89,17 @@ code.highlighter-rouge {
     max-width: 600px;
 }
 
+/* ========== brand colors ==========*/
+.ome-blue { color: #1d8dcd; }
+.ome-green { color: #128669; }
+.ome-red { color: #df283f; }
+.ome-navy { color: #1c4a87; }
+
+.bg-ome-blue { background-color: #1d8dcd; }
+.bg-ome-green { background-color: #128669; }
+.bg-ome-red { background-color: #df283f; }
+.bg-ome-navy { background-color: #1c4a87; }
+
 /* ========== headings ========== */
 h1, h2, h3, h4, h5, h6 {
     font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -270,7 +270,6 @@ h3.subdivider {
 
 /* ========== hero background images / callouts ==========*/
 section.announcement {
-    background-color: #e00;
     color: #fff;
     font-size: 14px;
     font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ many_thanks:
       alt_text: Agilo
 ---
         <!-- begin banner announcement -->
-        <section class="announcement">
+        <section class="announcement bg-ome-red">
             <span><i class="fa fa-bullhorn"></i> IMPORTANT: Critical security release - OMERO 5.6.1 now available - <a class="styled-link" href="{{ site.baseurl }}/2020/03/25/omero-5-6-1.html">Read the Announcement</a></span>
         </section>
         <!-- end banner announcement -->


### PR DESCRIPTION
(not high priority or anything)

This is just to make it easier to apply OME brand colors to pieces of the website. For example, you can change the "severity" of the banner announcement on the Home page by adding class `bg-ome-navy` or `bg-ome-red`. 