### PR TITLE
Add lightning talks page

### DIFF
--- a/_layouts/ome-community-meeting-program-2020.html
+++ b/_layouts/ome-community-meeting-program-2020.html
@@ -13,6 +13,7 @@ meta_description: The 2020 OME Community Meeting will be held remotely from May 
       <li class="{{ page.nav-day2 }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/day2/">Day 2 <span class="hide-for-small-only">- Wed May 27</span></a></li>
       <li class="{{ page.nav-workshops }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/workshops/">Day 3 <span class="hide-for-small-only">- Workshops</span></a></li>
       <li class="{{ page.nav-speakers }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/speakers/">Speakers</span></a></li>
+      <li class="{{ page.nav-speakers }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/lightning-talks/"><span class="show-for-small-only">Community</span> Lightning Talks</span></a></li>
     </ul>
 </header>
 

--- a/_layouts/ome-community-meeting-program-2020.html
+++ b/_layouts/ome-community-meeting-program-2020.html
@@ -12,8 +12,8 @@ meta_description: The 2020 OME Community Meeting will be held remotely from May 
       <li class="{{ page.nav-day1 }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/day1/">Day 1 <span class="hide-for-small-only">- Tue May 26</span></a></li>
       <li class="{{ page.nav-day2 }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/day2/">Day 2 <span class="hide-for-small-only">- Wed May 27</span></a></li>
       <li class="{{ page.nav-workshops }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/workshops/">Day 3 <span class="hide-for-small-only">- Workshops</span></a></li>
-      <li class="{{ page.nav-speakers }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/speakers/">Speakers</span></a></li>
-      <li class="{{ page.nav-speakers }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/lightning-talks/"><span class="show-for-small-only">Community</span> Lightning Talks</span></a></li>
+      <li class="{{ page.nav-speakers }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/speakers/">Speakers</a></li>
+      <li class="{{ page.nav-talks }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/lightning-talks/"><span class="show-for-small-only">Community</span> Lightning Talks</a></li>
     </ul>
 </header>
 

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -4,13 +4,9 @@ nav-overview: active
 title: Community Lightning Talks
 subheader: You can watch the lightning talks here
 speakers:
-    - firstname: Caterina
-      surname: Strambio De Castillia
-      aff: University of Massachusetts Medical School
-      link:
-    - firstname: Damir
-      surname: Sudar
-      aff: Quantitative Imaging Systems LLC
+    - firstname: Michelle
+      surname: Itano
+      aff: University of North Carolina, Dept. of Cell Biology & Physiology
       link:
     - firstname: Erick
       surname: Ratamero
@@ -20,21 +16,25 @@ speakers:
       surname: Sherman
       aff: Allen Institute for Cell Science
       link:
-    - firstname: Jorge
-      surname: Toledo
-      aff: REDECA / Universidad de Chile
+    - firstname: Caterina
+      surname: Strambio De Castillia
+      aff: University of Massachusetts Medical School
       link:
-    - firstname: Michelle
-      surname: Itano
-      aff: University of North Carolina, Dept. of Cell Biology & Physiology
-      link:
-    - firstname: Stefanie
-      surname: Weidtkamp-Peters
-      aff: Center for Advanced Imaging, University of Duesseldorf
+    - firstname: Damir
+      surname: Sudar
+      aff: Quantitative Imaging Systems LLC
       link:
     - firstname: Stephen
       surname: Taylor
       aff: Oxford University
+      link:
+    - firstname: Jorge
+      surname: Toledo
+      aff: REDECA / Universidad de Chile
+      link:
+    - firstname: Stefanie
+      surname: Weidtkamp-Peters
+      aff: Center for Advanced Imaging, University of Duesseldorf
       link:
 ---
 

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -4,108 +4,44 @@ nav-overview: active
 title: Community Lightning Talks
 subheader: You can watch the lightning talks here
 speakers:
-    - firstname: Chris
-      surname: Allan
-      aff: Glencoe Software, Inc.
-      link: "https://www.glencoesoftware.com/about/team/"
-    - firstname: Pete
-      surname: Bankhead
-      aff: University of Edinburgh
-      link: "https://www.ed.ac.uk/pathology/people/staff-students/peter-bankhead"
-    - firstname: Omer
-      surname: Bayraktar
-      aff: Wellcome Sanger Centre
-      link: "https://www.sanger.ac.uk/science/groups/bayraktar-group"
-    - firstname: Sebastien
-      surname: Besson
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
-    - firstname: Jean-Marie
-      surname: Burel
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
-    - firstname: JP
-      surname: Cartailler
-      aff: Vanderbilt University
-      link: "https://labnodes.vanderbilt.edu/member/profile/id/9436"
-    - firstname: Graham
-      surname: Johnson
-      aff: Allen Institute of Cell Science
-      link: "https://alleninstitute.org/what-we-do/cell-science/about/team/staff-profiles/graham-johnson/"
-    - firstname: Norio
-      surname: Kobayashi
-      aff: RIKEN
-      link: "https://www.riken.jp/en/research/labs/isc/data_knowl_org/index.html"
-    - firstname: Emma
-      surname: Lundberg
-      aff: SciLifeLab
-      link: "https://www.scilifelab.se/researchers/emma-lundberg/"
-    - firstname: Jian
-      surname: Ma
-      aff: Carnegie Mellon University
-      link: "https://www.cs.cmu.edu/~jianma/"
-    - firstname: Josh
-      surname: Moore
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
-    - firstname: Shuichi
-      surname: Onami
-      aff: RIKEN
-      link: "http://www.qbic.riken.jp/english/research/outline/lab-06.html"
-    - firstname: Federica
-      surname: Paina
-      aff: EMBL
-      link: "https://www.embl.de/research/units/cbb/imaging-infrastructure-strategy-development/members/index.php?s_personId=CP-60022940"
-    - firstname: Helen
-      surname: Parkinson
-      aff: EMBL-EBI
-      link: "https://www.ebi.ac.uk/about/people/helen-parkinson"
-    - firstname: Ugis
-      surname: Sarkans
-      aff: EMBL-EBI
-      link: "https://www.ebi.ac.uk/about/people/ugis-sarkans"
-    - firstname: Diane
-      surname: Saunders
-      aff: Vanderbilt University
-      link: "https://medicine.vumc.org/person/diane-saunders-phd"
-    - firstname: Nicholas
-      surname: Soforniew
-      aff: Chan Zuckerberg Initiative
-      link: "https://www.linkedin.com/in/nicholas-sofroniew-398179103"
-    - firstname: Peter
-      surname: Sorger
-      aff: Harvard Medical School
-      link: "https://sysbio.med.harvard.edu/peter-sorger"
     - firstname: Caterina
       surname: Strambio De Castillia
       aff: University of Massachusetts Medical School
-      link: "https://profiles.umassmed.edu/display/132167"
-    - firstname: Jason
-      surname: Swedlow
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
-    - firstname: Ola
-      surname: Tarkowska
-      aff: Wellcome Sanger Centre
-      link: "https://www.sanger.ac.uk/people/directory/aleksandra-ola-tarkowska"
-    - firstname: Sebastien
-      surname: Tosi
-      aff: IRB Barcelona
-      link: "https://www.irbbarcelona.org/en/profile/sebastien-tosi"
-    - firstname: Petr
-      surname: Walczysko
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
-    - firstname: Frances
-      surname: Wong
-      aff: The Open Microscopy Environment
-      link: "https://www.openmicroscopy.org/teams/"
+      link:
+    - firstname: Damir
+      surname: Sudar
+      aff: Quantitative Imaging Systems LLC
+      link:
+    - firstname: Erick
+      surname: Ratamero
+      aff: Research IT, The Jackson Laboratory
+      link:
+    - firstname: Jamie
+      surname: Sherman
+      aff: Allen Institute for Cell Science
+      link:
+    - firstname: Jorge
+      surname: Toledo
+      aff: REDECA / Universidad de Chile
+      link:
+    - firstname: Michelle
+      surname: Itano
+      aff: University of North Carolina, Dept. of Cell Biology & Physiology
+      link:
+    - firstname: Stefanie
+      surname: Weidtkamp-Peters
+      aff: Center for Advanced Imaging, University of Duesseldorf
+      link:
+    - firstname: Stephen
+      surname: Taylor
+      aff: Oxford University
+      link:
 ---
 
 <div class="row">
     <div class="row small-up-1 medium-up-2 text-center consortium-list">
         {% for speaker in page.speakers %}
-        <div class="columns"><a target="_blank" href="{{ speaker.link }}">{{ speaker.firstname }} {{ speaker.surname }}</a> <span class="institution">{{ speaker.aff }}</span></div>
+        <div class="columns">{% if speaker.link %}<a target="_blank" href="{{ speaker.link }}">{% endif %}{{ speaker.firstname }} {{ speaker.surname }}{% if speaker.link %}</a>{% endif %} <span class="institution">{{ speaker.aff }}</span></div>
         {% endfor %}
     </div>
 </div>

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -1,6 +1,6 @@
 ---
 layout: ome-community-meeting-program-2020
-nav-overview: active
+nav-talks: active
 title: Community Lightning Talks
 subheader: Links to the lightning talks will be available here
 speakers:

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -2,7 +2,7 @@
 layout: ome-community-meeting-program-2020
 nav-overview: active
 title: Community Lightning Talks
-subheader: You can watch the lightning talks here
+subheader: Links to the lightning talks will be available here
 speakers:
     - firstname: Michelle
       surname: Itano

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -24,10 +24,6 @@ speakers:
       surname: Sudar
       aff: Quantitative Imaging Systems LLC
       link:
-    - firstname: Stephen
-      surname: Taylor
-      aff: Oxford University
-      link:
     - firstname: Jorge
       surname: Toledo
       aff: REDECA / Universidad de Chile

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -16,10 +16,6 @@ speakers:
       surname: Sherman
       aff: Allen Institute for Cell Science
       link:
-    - firstname: Caterina
-      surname: Strambio De Castillia
-      aff: University of Massachusetts Medical School
-      link:
     - firstname: Damir
       surname: Sudar
       aff: Quantitative Imaging Systems LLC

--- a/events/ome-community-meeting-2020/lightning-talks/index.html
+++ b/events/ome-community-meeting-2020/lightning-talks/index.html
@@ -1,0 +1,111 @@
+---
+layout: ome-community-meeting-program-2020
+nav-overview: active
+title: Community Lightning Talks
+subheader: You can watch the lightning talks here
+speakers:
+    - firstname: Chris
+      surname: Allan
+      aff: Glencoe Software, Inc.
+      link: "https://www.glencoesoftware.com/about/team/"
+    - firstname: Pete
+      surname: Bankhead
+      aff: University of Edinburgh
+      link: "https://www.ed.ac.uk/pathology/people/staff-students/peter-bankhead"
+    - firstname: Omer
+      surname: Bayraktar
+      aff: Wellcome Sanger Centre
+      link: "https://www.sanger.ac.uk/science/groups/bayraktar-group"
+    - firstname: Sebastien
+      surname: Besson
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+    - firstname: Jean-Marie
+      surname: Burel
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+    - firstname: JP
+      surname: Cartailler
+      aff: Vanderbilt University
+      link: "https://labnodes.vanderbilt.edu/member/profile/id/9436"
+    - firstname: Graham
+      surname: Johnson
+      aff: Allen Institute of Cell Science
+      link: "https://alleninstitute.org/what-we-do/cell-science/about/team/staff-profiles/graham-johnson/"
+    - firstname: Norio
+      surname: Kobayashi
+      aff: RIKEN
+      link: "https://www.riken.jp/en/research/labs/isc/data_knowl_org/index.html"
+    - firstname: Emma
+      surname: Lundberg
+      aff: SciLifeLab
+      link: "https://www.scilifelab.se/researchers/emma-lundberg/"
+    - firstname: Jian
+      surname: Ma
+      aff: Carnegie Mellon University
+      link: "https://www.cs.cmu.edu/~jianma/"
+    - firstname: Josh
+      surname: Moore
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+    - firstname: Shuichi
+      surname: Onami
+      aff: RIKEN
+      link: "http://www.qbic.riken.jp/english/research/outline/lab-06.html"
+    - firstname: Federica
+      surname: Paina
+      aff: EMBL
+      link: "https://www.embl.de/research/units/cbb/imaging-infrastructure-strategy-development/members/index.php?s_personId=CP-60022940"
+    - firstname: Helen
+      surname: Parkinson
+      aff: EMBL-EBI
+      link: "https://www.ebi.ac.uk/about/people/helen-parkinson"
+    - firstname: Ugis
+      surname: Sarkans
+      aff: EMBL-EBI
+      link: "https://www.ebi.ac.uk/about/people/ugis-sarkans"
+    - firstname: Diane
+      surname: Saunders
+      aff: Vanderbilt University
+      link: "https://medicine.vumc.org/person/diane-saunders-phd"
+    - firstname: Nicholas
+      surname: Soforniew
+      aff: Chan Zuckerberg Initiative
+      link: "https://www.linkedin.com/in/nicholas-sofroniew-398179103"
+    - firstname: Peter
+      surname: Sorger
+      aff: Harvard Medical School
+      link: "https://sysbio.med.harvard.edu/peter-sorger"
+    - firstname: Caterina
+      surname: Strambio De Castillia
+      aff: University of Massachusetts Medical School
+      link: "https://profiles.umassmed.edu/display/132167"
+    - firstname: Jason
+      surname: Swedlow
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+    - firstname: Ola
+      surname: Tarkowska
+      aff: Wellcome Sanger Centre
+      link: "https://www.sanger.ac.uk/people/directory/aleksandra-ola-tarkowska"
+    - firstname: Sebastien
+      surname: Tosi
+      aff: IRB Barcelona
+      link: "https://www.irbbarcelona.org/en/profile/sebastien-tosi"
+    - firstname: Petr
+      surname: Walczysko
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+    - firstname: Frances
+      surname: Wong
+      aff: The Open Microscopy Environment
+      link: "https://www.openmicroscopy.org/teams/"
+---
+
+<div class="row">
+    <div class="row small-up-1 medium-up-2 text-center consortium-list">
+        {% for speaker in page.speakers %}
+        <div class="columns"><a target="_blank" href="{{ speaker.link }}">{{ speaker.firstname }} {{ speaker.surname }}</a> <span class="institution">{{ speaker.aff }}</span></div>
+        {% endfor %}
+    </div>
+</div>

--- a/events/ome-community-meeting-2020/speakers/index.html
+++ b/events/ome-community-meeting-2020/speakers/index.html
@@ -1,6 +1,6 @@
 ---
 layout: ome-community-meeting-program-2020
-nav-overview: active
+nav-speakers: active
 title: Our Speakers
 subheader: Learn more about our speakers here
 speakers:


### PR DESCRIPTION
This is the community lightning talks page proposed in the May-13 email from @pwalczysko:

Speaker data is as of what I downloaded as CSV from the registration form < 10 min ago.

I left the links blank for now, but when they're populated with the lightning talk video links, the link color will change and look just like the Speakers page.

(Not to be merged until we have the video content.)

Thanks!