### PR TITLE
Add workshop schedule

### DIFF
--- a/_includes/program_agenda.html
+++ b/_includes/program_agenda.html
@@ -1,3 +1,8 @@
+<div class="row column text-center">
+    <p>Please note that all times are in UK - British Summer Time (GMT+1).</p>
+</div>
+<hr class="invisible">
+
 {% for agenda_item in page.schedule %}
 <div class="row align-right">
     {% if agenda_item.videos %}<div class="medium-3 columns center-align"><img alt="{{ agenda_item.alt }} -" class="user-group-illustration center-align" src="{{ site.baseurl }}/img/icons/agenda-themes_{{ agenda_item.theme }}.svg"></div>{% endif %}

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -184,7 +184,7 @@ h3.subdivider {
     color: #127559;
 }
 
-.button.tiny { font-size: .65rem; }
+.button.tiny { font-size: .75rem; }
 
 /* ========== main navigation ==========*/
 .logo {
@@ -370,6 +370,12 @@ section.announcement a.styled-link {
     background-repeat: no-repeat;
     background-size: 960px, 100%;
     color: #263238; }
+.dropdown-pane {
+    border-color: #CFD8DC;
+    border-radius: 4px;
+    box-shadow: 0 2px 5px rgba(0,0,0,.25);
+    font-weight: 600;
+}
 
 .marketing-hero-omero-figure {
     background: #CFD8DC url('../img/bg/figures.svg') center center repeat;
@@ -878,7 +884,7 @@ ul.pagination li a {
     color: #ffffff;
 }
 
-p.tiny-print { font-size: 11px; }
+p.tiny-print { font-size: .8125rem; }
 
 ul.no-list-style {
     list-style: none;

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -372,9 +372,13 @@ section.announcement a.styled-link {
     color: #263238; }
 .dropdown-pane {
     border-color: #CFD8DC;
-    border-radius: 4px;
     box-shadow: 0 2px 5px rgba(0,0,0,.25);
     font-weight: 600;
+}
+.color-coded {
+    border: 1px solid #fff;
+    border-radius: 4px;
+    padding-top: 10px;
 }
 
 .marketing-hero-omero-figure {

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -10,6 +10,33 @@ schedule:
       time_track_b: "11:00 - 13:00"
       title_track_b: "OMERO Install and DevOps"
       details_track_b: Details to follow soon.
+    - time_track_a: "13:00 - 15:00"
+      title_track_a: "Next Gen File Formats"
+      details_track_a: Details to follow soon.
+      time_track_b: "13:00 - 14:00"
+      title_track_b: "OMERO.figure"
+      details_track_b: Details to follow soon.
+    - time_track_a: "16:00 - 18:00"
+      title_track_a: "Analysis with IDR"
+      details_track_a: Details to follow soon.
+      time_track_b: "15:00 - 17:00"
+      title_track_b: "Introduction to OMERO"
+      details_track_b: Details to follow soon.
+    - time_track_a: "19:00 - 21:00"
+      title_track_a: "Next Gen File Formats"
+      details_track_a: Details to follow soon.
+      time_track_b: "17:00 - 18:00"
+      title_track_b: "OMERO.figure"
+      details_track_b: Details to follow soon.
+    - time_track_a: "21:00 - 23:00"
+      title_track_a: "Analysis with IDR"
+      details_track_a: Details to follow soon.
+      time_track_b: "19:00 - 21:00"
+      title_track_b: "Large Import/Lessons from IDR"
+      details_track_b: Details to follow soon.
+    - time_track_b: "21:00 - 23:00"
+      title_track_b: "OMERO Install and DevOps"
+      details_track_b: Details to follow soon.
 ---
 
 {% for agenda_item in page.schedule %}

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -66,7 +66,7 @@ schedule:
 ---
 
 <div class="row column text-center">
-    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat). All times are in UK - British Summer Time (GMT+1).</p>
+    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat).<br>All times are in UK - British Summer Time (GMT+1).</p>
 </div>
 <hr class="invisible">
 

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -41,7 +41,7 @@ schedule:
 
 <div class="row">
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue">Track A</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue">Workshops</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
@@ -55,7 +55,7 @@ schedule:
         {% endfor %}
     </div>
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue">Track B</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue">Tutors</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -20,7 +20,7 @@ schedule:
       id_a: 2a
       description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "13:00 - 14:00"
-      title_track_b: "OMERO.figure with scripting"
+      title_track_b: "OMERO.figure with Scripting"
       color_code_b: "#E8F5E9"
       id_b: 2b
       description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
@@ -40,7 +40,7 @@ schedule:
       description_a:
       dirty_hack: yes
       time_track_b: "17:00 - 18:00"
-      title_track_b: "OMERO.figure with scripting"
+      title_track_b: "OMERO.figure with Scripting"
       color_code_b: "#E8F5E9"
       id_b: 4b
       description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
@@ -59,7 +59,7 @@ schedule:
       id_a: 5a
       description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
       time_track_b: "21:00 - 23:00"
-      title_track_b: "OMERO systems installation and configuration"
+      title_track_b: "OMERO Systems Installation and Configuration"
       color_code_b: "#E3F2FD"
       id_b: 6b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -66,7 +66,7 @@ schedule:
 ---
 
 <div class="row column text-center">
-    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat).</p>
+    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat). All times are in UK - British Summer Time (GMT+1).</p>
 </div>
 <hr class="invisible">
 

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -45,7 +45,7 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-4 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_a }}</div>
+            <div class="medium-4 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
             <div class="medium-8 columns">
                 <h5>{{ agenda_item.title_track_a }}</h5>
                 <p>{{ agenda_item.details_track_a }}</p>
@@ -59,7 +59,7 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-4 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_b }}</div>
+            <div class="medium-4 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
             <div class="medium-8 columns">
                 <h5>{{ agenda_item.title_track_b }}</h5>
                 <p>{{ agenda_item.details_track_b }}</p>

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -2,7 +2,7 @@
 layout: ome-community-meeting-program-2020
 nav-workshops: active
 title: Day 3 - Thursday, May 28
-subheader: Learn more about using OMERO through our practical workshops
+subheader: Learn more about working with OME’s tools and resources through our practical workshops
 schedule:
     - time_track_a: "11:00 - 13:00"
       title_track_a: "Introduction to OMERO"
@@ -66,13 +66,13 @@ schedule:
 ---
 
 <div class="row column text-center">
-    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat).<br>All times are in UK - British Summer Time (GMT+1).</p>
+    <p>All the workshops will run twice except <span class="bold">Large Import: Lessons from IDR</span>.<br>All times are in UK - British Summer Time (GMT+1).</p>
 </div>
 <hr class="invisible">
 
 <div class="row">
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>1st parallel</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>Stream 1</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
@@ -97,7 +97,7 @@ schedule:
         {% endfor %}
     </div>
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>2nd parallel</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>Stream 2</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -41,7 +41,7 @@ schedule:
 
 <div class="row">
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue">Workshops</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>1st parallel</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
@@ -55,7 +55,7 @@ schedule:
         {% endfor %}
     </div>
     <div class="small-6 medium-6 columns">
-        <div class="medium-12 columns"><h5 class="text-center ome-blue">Tutors</h5></div>
+        <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>2nd parallel</h5></div>
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -39,18 +39,33 @@ schedule:
       details_track_b: Details to follow soon.
 ---
 
-{% for agenda_item in page.schedule %}
-<div class="row align-right">
-    <div class="medium-2 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_a }}</div>
-    <div class="medium-4 columns">
-        <h5>{{ agenda_item.title_track_a }}</h5>
-        <p>{{ agenda_item.details_track_a }}</p>
+<div class="row">
+    <div class="small-6 medium-6 columns">
+        <div class="medium-12 columns"><h5 class="text-center ome-blue">Track A</h5></div>
+        <hr class="invisible">
+        {% for agenda_item in page.schedule %}
+        <div class="row align-right">
+            <div class="medium-4 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_a }}</div>
+            <div class="medium-8 columns">
+                <h5>{{ agenda_item.title_track_a }}</h5>
+                <p>{{ agenda_item.details_track_a }}</p>
+            </div>
+        </div>
+        <hr class="invisible">
+        {% endfor %}
     </div>
-    <div class="medium-2 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_b }}</div>
-    <div class="medium-4 columns">
-        <h5>{{ agenda_item.title_track_b }}</h5>
-        <p>{{ agenda_item.details_track_b }}</p>
+    <div class="small-6 medium-6 columns">
+        <div class="medium-12 columns"><h5 class="text-center ome-blue">Track B</h5></div>
+        <hr class="invisible">
+        {% for agenda_item in page.schedule %}
+        <div class="row align-right">
+            <div class="medium-4 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_b }}</div>
+            <div class="medium-8 columns">
+                <h5>{{ agenda_item.title_track_b }}</h5>
+                <p>{{ agenda_item.details_track_b }}</p>
+            </div>
+        </div>
+        <hr class="invisible">
+        {% endfor %}
     </div>
 </div>
-<hr class="invisible">
-{% endfor %}

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -6,26 +6,32 @@ subheader: Learn more about using OMERO through our practical workshops
 schedule:
     - time_track_a: "11:00 - 13:00"
       title_track_a: "Introduction to OMERO"
+      color_code_a: "#FFEBEE"
       id_a: 1a
       description_a: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
       time_track_b: "11:00 - 13:00"
       title_track_b: "OMERO systems installation and configuration"
+      color_code_b: "#E3F2FD"
       id_b: 1b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
     - time_track_a: "13:00 - 15:00"
       title_track_a: "Next Gen File Formats"
+      color_code_a: "#E0F2F1"
       id_a: 2a
       description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "13:00 - 14:00"
       title_track_b: "OMERO.figure with scripting"
+      color_code_b: "#E8F5E9"
       id_b: 2b
       description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
     - time_track_a: "16:00 - 18:00"
       title_track_a: "Analysis with IDR"
+      color_code_a: "#ECEFF1"
       id_a: 3a
       description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
       time_track_b: "15:00 - 17:00"
       title_track_b: "Introduction to OMERO"
+      color_code_b: "#FFEBEE"
       id_b: 3b
       description_b: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
     - time_track_a: "\xA0"
@@ -35,10 +41,12 @@ schedule:
       dirty_hack: yes
       time_track_b: "17:00 - 18:00"
       title_track_b: "OMERO.figure with scripting"
+      color_code_b: "#E8F5E9"
       id_b: 4b
       description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
     - time_track_a: "19:00 - 21:00"
       title_track_a: "Next Gen File Formats"
+      color_code_a: "#E0F2F1"
       id_a: 4a
       description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "19:00 - 21:00"
@@ -47,10 +55,12 @@ schedule:
       description_b: "Possibilities for importing large and heterogeneous data into OMERO will be explored. This includes command-line import, in-place import and bulk import."
     - time_track_a: "21:00 - 23:00"
       title_track_a: "Analysis with IDR"
+      color_code_a: "#ECEFF1"
       id_a: 5a
       description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
       time_track_b: "21:00 - 23:00"
       title_track_b: "OMERO systems installation and configuration"
+      color_code_b: "#E3F2FD"
       id_b: 6b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
 ---
@@ -67,16 +77,16 @@ schedule:
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
             <div class="medium-3 columns bold">{% if agenda_item.id_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
-            <div class="medium-9 columns">
+            <div class="medium-9 columns color-coded" style="background-color: {{ agenda_item.color_code_a }};">
                 <h5>{{ agenda_item.title_track_a }}</h5>
                 {% if agenda_item.dirty_hack %}
-                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}" style="visibility: hidden;">View Description</button>
+                <button class="button small" type="button" data-toggle="{{ agenda_item.id_a }}" style="visibility: hidden;">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_a }}</p>
                 </div>
                 {% endif %}
                 {% if agenda_item.id_a %}
-                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}">View Description</button>
+                <button class="button small" type="button" data-toggle="{{ agenda_item.id_a }}">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_a }}</p>
                 </div>
@@ -92,10 +102,10 @@ schedule:
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
             <div class="medium-3 columns bold">{% if agenda_item.id_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
-            <div class="medium-9 columns">
+            <div class="medium-9 columns color-coded" style="background-color: {{ agenda_item.color_code_b }};">
                 <h5>{{ agenda_item.title_track_b }}</h5>
                 {% if agenda_item.time_track_b %}
-                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_b }}">View Description</button>
+                <button class="button small" type="button" data-toggle="{{ agenda_item.id_b }}">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_b }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_b }}</p>
                 </div>

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -3,19 +3,27 @@ layout: ome-community-meeting-program-2020
 nav-workshops: active
 title: Day 3 - Thursday, May 28
 subheader: Learn more about using OMERO through our practical workshops
+schedule:
+    - time_track_a: "11:00 - 13:00"
+      title_track_a: "Introduction to OMERO"
+      details_track_a: Details to follow soon.
+      time_track_b: "11:00 - 13:00"
+      title_track_b: "OMERO Install and DevOps"
+      details_track_b: Details to follow soon.
 ---
 
-<div class="row">
-    <div class="small-12 medium-6 medium-offset-3 columns">
-        <div class="card card-support">
-            <div class="card-section">
-                <i class="border-green icon-green fa fa-comments-o fa-2x"></i>
-                <h4>Workshops TBD</h4>
-                <p class="card-caption">
-                    Workshops are still to be determined but if you are interested in running one, please reach out to <a href=" mailto:J.Matthew@dundee.ac.uk,j.r.swedlow@dundee.ac.uk?subject=I want to run a workshop!">June Matthew and Jason Swedlow</a>.
-                </p>
-                <p class="text-center"><a href=" mailto:J.Matthew@dundee.ac.uk,j.r.swedlow@dundee.ac.uk?subject=I want to run a workshop!" class="btn-blue button small">I want to run a workshop!</a></p>
-            </div>
-        </div>
+{% for agenda_item in page.schedule %}
+<div class="row align-right">
+    <div class="medium-2 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_a }}</div>
+    <div class="medium-4 columns">
+        <h5>{{ agenda_item.title_track_a }}</h5>
+        <p>{{ agenda_item.details_track_a }}</p>
     </div>
-  </div>
+    <div class="medium-2 columns bold"><i class="fa fa-clock-o"></i> {{ agenda_item.time_track_b }}</div>
+    <div class="medium-4 columns">
+        <h5>{{ agenda_item.title_track_b }}</h5>
+        <p>{{ agenda_item.details_track_b }}</p>
+    </div>
+</div>
+<hr class="invisible">
+{% endfor %}

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -28,23 +28,28 @@ schedule:
       title_track_b: "Introduction to OMERO"
       id_b: 3b
       description_b: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
-    - time_track_a: "19:00 - 21:00"
-      title_track_a: "Next Gen File Formats"
-      id_a: 4a
-      description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
+    - time_track_a: "\xA0"
+      title_track_a: "\xA0"
+      id_a:
+      description_a:
+      dirty_hack: yes
       time_track_b: "17:00 - 18:00"
       title_track_b: "OMERO.figure with scripting"
       id_b: 4b
       description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
-    - time_track_a: "21:00 - 23:00"
-      title_track_a: "Analysis with IDR"
-      id_a: 5a
-      description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
+    - time_track_a: "19:00 - 21:00"
+      title_track_a: "Next Gen File Formats"
+      id_a: 4a
+      description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "19:00 - 21:00"
       title_track_b: "Large Import: Lessons from IDR"
       id_b: 5b
       description_b: "Possibilities for importing large and heterogeneous data into OMERO will be explored. This includes command-line import, in-place import and bulk import."
-    - time_track_b: "21:00 - 23:00"
+    - time_track_a: "21:00 - 23:00"
+      title_track_a: "Analysis with IDR"
+      id_a: 5a
+      description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
+      time_track_b: "21:00 - 23:00"
       title_track_b: "OMERO systems installation and configuration"
       id_b: 6b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
@@ -56,10 +61,16 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-3 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
+            <div class="medium-3 columns bold">{% if agenda_item.id_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_a }}</h5>
-                {% if agenda_item.time_track_a %}
+                {% if agenda_item.dirty_hack %}
+                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}" style="visibility: hidden;">View Description</button>
+                <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
+                    <p class="tiny-print">{{ agenda_item.description_a }}</p>
+                </div>
+                {% endif %}
+                {% if agenda_item.id_a %}
                 <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_a }}</p>
@@ -75,7 +86,7 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-3 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
+            <div class="medium-3 columns bold">{% if agenda_item.id_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_b }}</h5>
                 {% if agenda_item.time_track_b %}

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -6,37 +6,30 @@ subheader: Learn more about using OMERO through our practical workshops
 schedule:
     - time_track_a: "11:00 - 13:00"
       title_track_a: "Introduction to OMERO"
-      details_track_a: Details to follow soon.
+      id_a: 1a
+      description_a: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
       time_track_b: "11:00 - 13:00"
       title_track_b: "OMERO Install and DevOps"
-      details_track_b: Details to follow soon.
+      id_b: 1b
+      description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
     - time_track_a: "13:00 - 15:00"
       title_track_a: "Next Gen File Formats"
-      details_track_a: Details to follow soon.
       time_track_b: "13:00 - 14:00"
       title_track_b: "OMERO.figure"
-      details_track_b: Details to follow soon.
     - time_track_a: "16:00 - 18:00"
       title_track_a: "Analysis with IDR"
-      details_track_a: Details to follow soon.
       time_track_b: "15:00 - 17:00"
       title_track_b: "Introduction to OMERO"
-      details_track_b: Details to follow soon.
     - time_track_a: "19:00 - 21:00"
       title_track_a: "Next Gen File Formats"
-      details_track_a: Details to follow soon.
       time_track_b: "17:00 - 18:00"
       title_track_b: "OMERO.figure"
-      details_track_b: Details to follow soon.
     - time_track_a: "21:00 - 23:00"
       title_track_a: "Analysis with IDR"
-      details_track_a: Details to follow soon.
       time_track_b: "19:00 - 21:00"
       title_track_b: "Large Import/Lessons from IDR"
-      details_track_b: Details to follow soon.
     - time_track_b: "21:00 - 23:00"
       title_track_b: "OMERO Install and DevOps"
-      details_track_b: Details to follow soon.
 ---
 
 <div class="row">
@@ -48,7 +41,10 @@ schedule:
             <div class="medium-3 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_a }}</h5>
-                <p>{{ agenda_item.details_track_a }}</p>
+                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}">View Description</button>
+                <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
+                    <p class="tiny-print">{{ agenda_item.description_a }}</p>
+                </div>
             </div>
         </div>
         <hr class="invisible">
@@ -62,7 +58,10 @@ schedule:
             <div class="medium-3 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_b }}</h5>
-                <p>{{ agenda_item.details_track_b }}</p>
+                <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_b }}">View Description</button>
+                <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_b }}" data-dropdown data-auto-focus="true">
+                    <p class="tiny-print">{{ agenda_item.description_b }}</p>
+                </div>
             </div>
         </div>
         <hr class="invisible">

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -45,8 +45,8 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-4 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
-            <div class="medium-8 columns">
+            <div class="medium-3 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
+            <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_a }}</h5>
                 <p>{{ agenda_item.details_track_a }}</p>
             </div>
@@ -59,8 +59,8 @@ schedule:
         <hr class="invisible">
         {% for agenda_item in page.schedule %}
         <div class="row align-right">
-            <div class="medium-4 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
-            <div class="medium-8 columns">
+            <div class="medium-3 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
+            <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_b }}</h5>
                 <p>{{ agenda_item.details_track_b }}</p>
             </div>

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -55,6 +55,11 @@ schedule:
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
 ---
 
+<div class="row column text-center">
+    <p>Please note that with the exception of <span class="bold">Large Import: Lessons from IDR</span>, all the workshops have 2 occurences (1 occurence and 1 repeat).</p>
+</div>
+<hr class="invisible">
+
 <div class="row">
     <div class="small-6 medium-6 columns">
         <div class="medium-12 columns"><h5 class="text-center ome-blue"><span class="hide-for-small-only">Workshop - </span>1st parallel</h5></div>

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -59,10 +59,12 @@ schedule:
             <div class="medium-3 columns bold">{% if agenda_item.time_track_a %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_a }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_a }}</h5>
+                {% if agenda_item.time_track_a %}
                 <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_a }}">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_a }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_a }}</p>
                 </div>
+                {% endif %}
             </div>
         </div>
         <hr class="invisible">
@@ -76,11 +78,13 @@ schedule:
             <div class="medium-3 columns bold">{% if agenda_item.time_track_b %}<i class="fa fa-clock-o"></i>{% endif %} {{ agenda_item.time_track_b }}</div>
             <div class="medium-9 columns">
                 <h5>{{ agenda_item.title_track_b }}</h5>
+                {% if agenda_item.time_track_b %}
                 <button class="button small hollow" type="button" data-toggle="{{ agenda_item.id_b }}">View Description</button>
                 <div class="dropdown-pane" data-position="bottom" data-alignment="left" id="{{ agenda_item.id_b }}" data-dropdown data-auto-focus="true">
                     <p class="tiny-print">{{ agenda_item.description_b }}</p>
                 </div>
             </div>
+            {% endif %}
         </div>
         <hr class="invisible">
         {% endfor %}

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -9,27 +9,45 @@ schedule:
       id_a: 1a
       description_a: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
       time_track_b: "11:00 - 13:00"
-      title_track_b: "OMERO Install and DevOps"
+      title_track_b: "OMERO systems installation and configuration"
       id_b: 1b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
     - time_track_a: "13:00 - 15:00"
       title_track_a: "Next Gen File Formats"
+      id_a: 2a
+      description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "13:00 - 14:00"
-      title_track_b: "OMERO.figure"
+      title_track_b: "OMERO.figure with scripting"
+      id_b: 2b
+      description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
     - time_track_a: "16:00 - 18:00"
       title_track_a: "Analysis with IDR"
+      id_a: 3a
+      description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
       time_track_b: "15:00 - 17:00"
       title_track_b: "Introduction to OMERO"
+      id_b: 3b
+      description_b: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
     - time_track_a: "19:00 - 21:00"
       title_track_a: "Next Gen File Formats"
+      id_a: 4a
+      description_a: "From pyramidal OME-TIFFs to Zarr/n5 prototypes, we will walk through several recent and upcoming developments in our search for a next-general file format (NGFF). Demos include ImageJ macros, Bio-Formats command-line tools, an ome-zarr plugin for napari, and an OMERO microservice for publishing Zarr filesets."
       time_track_b: "17:00 - 18:00"
-      title_track_b: "OMERO.figure"
+      title_track_b: "OMERO.figure with scripting"
+      id_b: 4b
+      description_b: "An overview of OMERO.figure, including some advanced features. This will be followed by an introduction to the creation and editing of figures in Python and JavaScript."
     - time_track_a: "21:00 - 23:00"
       title_track_a: "Analysis with IDR"
+      id_a: 5a
+      description_a: "We will give an overview of the various analysis entry points. We will then focus on analysing data using the Python API. We will show how to set up a Conda environment and how to integrate with 3rd party Python analysis tools such as ilastik."
       time_track_b: "19:00 - 21:00"
-      title_track_b: "Large Import/Lessons from IDR"
+      title_track_b: "Large Import: Lessons from IDR"
+      id_b: 5b
+      description_b: "Possibilities for importing large and heterogeneous data into OMERO will be explored. This includes command-line import, in-place import and bulk import."
     - time_track_b: "21:00 - 23:00"
-      title_track_b: "OMERO Install and DevOps"
+      title_track_b: "OMERO systems installation and configuration"
+      id_b: 6b
+      description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."
 ---
 
 <div class="row">

--- a/events/ome-community-meeting-2020/workshops/index.html
+++ b/events/ome-community-meeting-2020/workshops/index.html
@@ -10,7 +10,7 @@ schedule:
       id_a: 1a
       description_a: "Basic concepts, import, viewing and management of images and metadata in OMERO will be introduced. Data mining using OMERO.web and its extensions, such as OMERO.parade, will be shown. No previous knowledge about OMERO is assumed."
       time_track_b: "11:00 - 13:00"
-      title_track_b: "OMERO systems installation and configuration"
+      title_track_b: "OMERO Systems Installation and Configuration"
       color_code_b: "#E3F2FD"
       id_b: 1b
       description_b: "Over the past few years we have updated our OMERO deployment instructions to follow modern deployment practices. These take advantage of automation tools such as Ansible and Docker to ensure you can reliably and reproducibly install and upgrade your OMERO.servers. This workshop will introduce you to some of the resources available, and will include some live demonstrations. This will be followed by time for a general discussion or questions, for instance on deployments such as the IDR."


### PR DESCRIPTION
Adds workshop schedule from @pwalczysko's comment in https://trello.com/c/RIcmFL52/21-virtual-agenda#comment-5ebe75095270d6516ec87667

I agree that links should be added later when they're finalized. You can replace the "Details to follow soon" text with them as they become ready.