### PR TITLE
Remove links to OME 2020 registration form

### DIFF
--- a/_layouts/ome-community-meeting-program-2020.html
+++ b/_layouts/ome-community-meeting-program-2020.html
@@ -12,7 +12,7 @@ meta_description: The 2020 OME Community Meeting will be held remotely from May 
 <header class="header" id="bg-hero-ome-community-meeting-2020-agenda">
     <h1>2020 OME Community Meeting</h1>
     <p class="bold ome-navy text-shadow-light">Open data, advanced imaging data applications, and more</p>
-    <p><a href="#" class="large button sites-button btn-red margin-right">Registration closed</a></p>
+    <p><span class="large button sites-button btn-red margin-right">Registration closed</span></p>
     <ul class="header-subnav bg-ome-navy">
       <li class="{{ page.nav-overview }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/">Overview</a></li>
       <li class="{{ page.nav-day1 }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/day1/">Day 1 <span class="hide-for-small-only">- Tue May 26</span></a></li>

--- a/_layouts/ome-community-meeting-program-2020.html
+++ b/_layouts/ome-community-meeting-program-2020.html
@@ -5,14 +5,14 @@ meta_description: The 2020 OME Community Meeting will be held remotely from May 
 
 <!-- begin banner announcement -->
 <section class="announcement bg-ome-red">
-    <span><i class="fa fa-bullhorn"></i> Please note the registration deadline is 19 May - <a class="styled-link" href="https://docs.google.com/forms/d/1ZOl1wa_oe5Pm4ho2co05ZD3otXpGY_3hPaFxnlvGyiQ">Last chance to register!</a></span>
+    <span></span>
 </section>
 <!-- end banner announcement -->
 
 <header class="header" id="bg-hero-ome-community-meeting-2020-agenda">
     <h1>2020 OME Community Meeting</h1>
     <p class="bold ome-navy text-shadow-light">Open data, advanced imaging data applications, and more</p>
-    <p><a href="https://docs.google.com/forms/d/1ZOl1wa_oe5Pm4ho2co05ZD3otXpGY_3hPaFxnlvGyiQ" class="large button sites-button btn-red margin-right">Register to Attend</a></p>
+    <p><a href="#" class="large button sites-button btn-red margin-right">Registration closed</a></p>
     <ul class="header-subnav bg-ome-navy">
       <li class="{{ page.nav-overview }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/">Overview</a></li>
       <li class="{{ page.nav-day1 }}"><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/day1/">Day 1 <span class="hide-for-small-only">- Tue May 26</span></a></li>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ many_thanks:
 ---
         <!-- begin banner announcement -->
         <section class="announcement bg-ome-red">
-            <span><i class="fa fa-bullhorn"></i> Please note the registration deadline is 19 May - <a class="styled-link" href="https://docs.google.com/forms/d/1ZOl1wa_oe5Pm4ho2co05ZD3otXpGY_3hPaFxnlvGyiQ">Last chance to register!</a></span>
+            <span></span>
         </section>
         <!-- end banner announcement -->
 


### PR DESCRIPTION
Remove links to OME 2020 registration form on the front page and meeting pages.

![Screenshot 2020-05-20 at 16 41 37](https://user-images.githubusercontent.com/900055/82466976-fdbe7980-9ab8-11ea-914c-c99753cb4026.png)


