### PR TITLE
Remove the subheader text

### DIFF
--- a/events/ome-community-meeting-2020/index.html
+++ b/events/ome-community-meeting-2020/index.html
@@ -2,7 +2,6 @@
 layout: ome-community-meeting-program-2020
 nav-overview: active
 title: Overview
-subheader: Registration is now open!
 ---
 
 <div class="row">


### PR DESCRIPTION
Removing the outdated subheader "Registration is now open"

cc @jrswedlow 