### PR TITLE
htmlproofer: reenable external linkchecking for 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ services:
 
 script:
   - docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
+  # Report 4xx status codes except 429 errors (Too Many Requests)
+  # typically sent by GitHub while linkchecking the downloads
   - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429"
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 script:
   - docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-  - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --disable-external
+  - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429"
 
 before_deploy:
   - tar -zcvf ${TRAVIS_REPO_SLUG#*/}.tar.gz -C _site ./

--- a/_posts/2017-05-25-bio-formats-5-5-1.md
+++ b/_posts/2017-05-25-bio-formats-5-5-1.md
@@ -36,7 +36,7 @@ Updated build system:
 
 Documentation improvements:
 
--  added a [new example file](https://github.com/openmicroscopy/bioformats/blob/develop/docs/sphinx/developers/examples/OrthogonalReader.java) for reading and writing of XZ and YZ orthogonal planes
+-  added a [new example file](https://github.com/ome/bioformats/blob/v5.5.1/docs/sphinx/developers/examples/OrthogonalReader.java) for reading and writing of XZ and YZ orthogonal planes
 
 
 The software is available to download now and will shortly be available from

--- a/_posts/2018-02-23-user-meeting-registration.md
+++ b/_posts/2018-02-23-user-meeting-registration.md
@@ -4,7 +4,7 @@ title: 2018 OME Annual Users Meeting registration
 intro-blurb: The OME team is pleased to announce that registration for the 2018 OME Annual Users Meeting is now open
 ---
 
-We are pleased to announce that registration for the 2018 OME Annual Users Meeting is now open.
+We are pleased to announce that registration for the 2018 OME Annual Users Meeting is now closed.
 
 The meeting will be held May 30th - June 1st 2018 at the University of Dundee,
 Scotland, UK.

--- a/_posts/2018-02-23-user-meeting-registration.md
+++ b/_posts/2018-02-23-user-meeting-registration.md
@@ -4,7 +4,7 @@ title: 2018 OME Annual Users Meeting registration
 intro-blurb: The OME team is pleased to announce that registration for the 2018 OME Annual Users Meeting is now open
 ---
 
-We are pleased to announce that registration for the 2018 OME Annual Users Meeting is now open. [Register now](https://www.buyat.dundee.ac.uk/conferences-and-events/school-of-life-sciences/ome-annual-users-meeting/2018-ome-annual-users-meeting).
+We are pleased to announce that registration for the 2018 OME Annual Users Meeting is now open.
 
 The meeting will be held May 30th - June 1st 2018 at the University of Dundee,
 Scotland, UK.

--- a/about/index.html
+++ b/about/index.html
@@ -69,8 +69,6 @@ partnerships1:
       group1_link: "http://icy.bioimageanalysis.org/"
     - group1_name: "XuvTools"
       group1_link: "http://www.xuvtools.org/"
-    - group1_name: "Macnification"
-      group1_link: "http://www.orbicule.com/macnification/"
     - group1_name: "CellProfiler"
       group1_link: "http://www.cellprofiler.org/"
     - group1_name: "Bisque"

--- a/about/index.html
+++ b/about/index.html
@@ -53,7 +53,7 @@ consortium:
       member_link: "http://murphylab.web.cmu.edu"
       institution: "Carnegie Mellon University"
     - member_name: "Dr Spencer Shorte"
-      member_link: "https://research.pasteur.fr/en/team/imagopole/"
+      member_link: "https://research.pasteur.fr/en/team/photonic-bioimaging-utechs-pbi/"
       institution: "Institut Pasteur"
     - member_name: "Dr Gianluigi Zanetti"
       member_link: "http://www.crs4.it/research/data-intensive-computing/"

--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -98,7 +98,7 @@ meta_description: Commercial licenses and deployments of our software are availa
             <div class="column"><a target="_blank" href="http://www.intelligent-imaging.com"><div class="card-consortium card"><div class="card-section">Intelligent Imaging Innovations, Inc.</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.leica-microsystems.com/"><div class="card-consortium card"><div class="card-section">Leica Inc.</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.moleculardevices.com"><div class="card-consortium card"><div class="card-section">Molecular Devices Inc.</div></div></a></div>
-            <div class="column"><a target="_blank" href="http://las.perkinelmer.com/"><div class="card-consortium card"><div class="card-section">PerkinElmer Life and Analytical Sciences Inc.</div></div></a></div>
+            <div class="column"><a target="_blank" href="http://www.perkinelmer.com/"><div class="card-consortium card"><div class="card-section">PerkinElmer Life and Analytical Sciences Inc.</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.scientifica.uk.com"><div class="card-consortium card"><div class="card-section">Scientifica</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.svi.nl/"><div class="card-consortium card"><div class="card-section">Scientific Volume Imaging B.V.</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.till-photonics.com/"><div class="card-consortium card"><div class="card-section">TILL Photonics GmbH</div></div></a></div>

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -154,7 +154,7 @@ meta_description: A listing of individuals and groups who have made contribution
             </div>
 
             <div class="large-expand columns">
-            Barry DeZonia <a target="_blank" href="http://loci.wisc.edu/people/barry-dezonia">UW-Madison LOCI</a>
+            Barry DeZonia <a target="_blank" href="http://loci.wisc.edu/">UW-Madison LOCI</a>
             </div>
 
             <div class="large-expand columns">
@@ -198,7 +198,7 @@ meta_description: A listing of individuals and groups who have made contribution
             </div>
 
             <div class="large-expand columns">
-            Aivar Grislis <a target="_blank" href="http://loci.wisc.edu/people/aivar-grislis">UW-Madison LOCI</a>
+            Aivar Grislis <a target="_blank" href="http://loci.wisc.edu/">UW-Madison LOCI</a>
             </div>
 
             <div class="large-expand columns">
@@ -338,7 +338,7 @@ meta_description: A listing of individuals and groups who have made contribution
             </div>
 
             <div class="large-expand columns">
-            Ville Rantanen <a target="_blank" href="http://www.helsinki.fi/university/">University of Helsinki</a>
+            Ville Rantanen <a target="_blank" href="http://www.helsinki.fi/en/">University of Helsinki</a>
             </div>
 
             <div class="large-expand columns">
@@ -354,7 +354,7 @@ meta_description: A listing of individuals and groups who have made contribution
             </div>
 
             <div class="large-expand columns">
-            Johannes Schindelin <a target="_blank" href="http://loci.wisc.edu/people/johannes-schindelin">UW-Madison LOCI</a>, <a target="_blank" href="http://fiji.sc/">Fiji Project</a>, <a target="_blank" href="http://www.mpi-cbg.de/">Max-Planck Institute of Molecular Cell Biology in Dresden</a>
+            Johannes Schindelin <a target="_blank" href="http://loci.wisc.edu/">UW-Madison LOCI</a>, <a target="_blank" href="http://fiji.sc/">Fiji Project</a>, <a target="_blank" href="http://www.mpi-cbg.de/">Max-Planck Institute of Molecular Cell Biology in Dresden</a>
             </div>
 
             <div class="large-expand columns">

--- a/omero/developers/docs.html
+++ b/omero/developers/docs.html
@@ -24,16 +24,6 @@ meta_description: Extensive documentation on the functionality of OMERO.
                 </a>
             </div>
             <div class="column">
-                <a href="https://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/api/" target="_blank">
-                    <div class="card card-docs top-gray">
-                        <div class="card-section">
-                            <h5 class="doc-title">OMERO API documentation</h5>
-                            <span class="doc-cta">Read the Docs <i class="fa fa-long-arrow-right"></i></span>
-                        </div>
-                    </div>
-                </a>
-            </div>
-            <div class="column">
                 <a href="https://docs.openmicroscopy.org/contributing/" target="_blank">
                     <div class="card card-docs top-blue">
                         <div class="card-section">

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -136,7 +136,7 @@ meta_description: Download the latest version of OMERO here.
                         <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_java.png">
                         <h5>Java (Ice 3.6)</h5>
                         <h6>OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
-                        <p class="card-caption">The OMERO Java API documentation is available to read on the web <a href="https://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/api/">here</a>.</p>
+                        <p class="card-caption">The OMERO Java documentation is available to read on the web <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/Java.html">here</a>.</p>
                         <a href="https://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (125 MB)</a>
                     </div>
                 </div>

--- a/teams/index.html
+++ b/teams/index.html
@@ -117,7 +117,7 @@ development_teams:
     - team_name: Murphy Lab
       link: "http://murphylab.web.cmu.edu"
     - team_name: Shorte Lab
-      link: "http://research.pasteur.fr/en/team/imagopole/"
+      link: "https://research.pasteur.fr/en/team/photonic-bioimaging-utechs-pbi/"
     - team_name: Zanetti Lab
       link: "http://www.crs4.it/research/data-intensive-computing/"
 ---


### PR DESCRIPTION
The `htmlproofer` step had been disabled for all external link. This PR selectively re-enables it at least to check for 4xx errors (except 429 which are typically thrown by GitHub downloads URLs)

A few broken links are also fixed or removed when no alternate solution was found.