### PR TITLE
Add BIOQUANT to list of commercial partners that support OME-TIFF

### DIFF
--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -90,6 +90,7 @@ meta_description: Commercial licenses and deployments of our software are availa
         <div id="partnerships" class="row small-up-2 medium-up-2">
             <h5 class="text-center">Organizations supporting OME-TIFF</h5>
             <div class="column"><a target="_blank" href="http://www.api.com/"><div class="card-consortium card"><div class="card-section">Applied Precision, Inc.</div></div></a></div>
+            <div class="column"><a target="_blank" href="https://bioquant.com"><div class="card-consortium card"><div class="card-section">BIOQUANT Image Analysis Corporation</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.bitplane.com/"><div class="card-consortium card"><div class="card-section">Bitplane AG</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.zeiss.de/axiovision"><div class="card-consortium card"><div class="card-section">Carl Zeiss Imaging Solutions GmbH</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.zeiss.de/micro"><div class="card-consortium card"><div class="card-section">Carl Zeiss MicroImaging GmbH</div></div></a></div>


### PR DESCRIPTION
As discussed in Tuesday meeting, this adds BIOQUANT as a commercial partner.  See also https://community.bioquant.com/latest-osteo-features.