### PR TITLE
Community meeting updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_minutes"]
+	path = _minutes
+	url = git://github.com/ome/meeting-minutes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_minutes"]
 	path = _minutes
-	url = ../meeting-minutes
+	url = https://github.com/ome/meeting-minutes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_minutes"]
 	path = _minutes
-	url = git://github.com/ome/meeting-minutes
+	url = ../meeting-minutes

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
   # Report 4xx status codes except 429 errors (Too Many Requests)
   # typically sent by GitHub while linkchecking the downloads
-  - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429"
+  - docker run -it  --rm -v $(pwd)/_site:/site -it jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/'
 
 before_deploy:
   - tar -zcvf ${TRAVIS_REPO_SLUG#*/}.tar.gz -C _site ./

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,25 @@ plugins:
 paginate: 10
 paginate_path: "/announcements/page:num/"
 
+collections:
+    minutes:
+        output: true
+defaults:
+  - scope:
+      path: ""
+      type: "minutes"
+    values:
+      layout: "minute"
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+  - scope:
+      path: ""
+    values:
+      layout: "default"
+
 future: true
 
 bf:

--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -27,6 +27,7 @@
                             <li><a href="{{ site.baseurl }}/news/">Overview</a></li>
                             <li><a href="{{ site.baseurl }}/announcements/">Announcements</a></li>
                             <li><a href="{{ site.baseurl }}/events/">Events</a></li>
+                            <li><a href="{{ site.baseurl }}/minutes/">Minutes</a
                             <li><a href="{{ site.baseurl }}/security/">Security</a></li>
                             <li><a href="{{ site.baseurl }}/careers/">Careers</a></li>
                             <li><a href="https://blog.openmicroscopy.org/">Blog</a></li>

--- a/_layouts/minute.html
+++ b/_layouts/minute.html
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+        <!-- begin Post -->
+        <div class="callout large primary" id="bg-image-announcements">
+            <div class="row column text-center">
+                <h1>{{page.title}}</h1>
+                <p>{{page.intro-blurb}}</p>
+            </div>
+        </div>
+        <hr class="invisible">        
+        <div class="text-center">
+            <a id="back-to-top" href="{{ site.baseurl }}/announcements/"><i class="fa fa-arrow-left"></i> back to Announcements</a>
+        </div>
+        <hr class="invisible">        
+        <div class="row">
+            <div class="columns">
+            {{content}}
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <p class="text-right">
+                    &mdash; <i>{{ page.date | date: '%B %-d, %Y' }}</i>
+                </p>
+            </div>
+        </div>
+        <!-- end Post -->

--- a/events/omero-users-workshop-hamilton-november-2019.html
+++ b/events/omero-users-workshop-hamilton-november-2019.html
@@ -12,7 +12,7 @@ main-blurb: One day workshop on how to use OMERO held in Hamilton, New Zealand.
         </div>
         <div class="row">
             <div class="column">
-                <h2 class="event-day">Organiser: <a href="https://www.ivvy.com.au/event/Y7FLHK/workshops.html" target="_blank">workshop at the 29th New Zealand Conference on Microscopy</a></h2>
+                <h2 class="event-day">Organiser: workshop at the 29th New Zealand Conference on Microscopy</h2>
             </div>
         </div>
         <div class="row">

--- a/minutes/index.html
+++ b/minutes/index.html
@@ -1,0 +1,29 @@
+---
+layout: news
+title: Meeting Minutes
+filename: minutes
+main-blurb: Minutes from the weekly OME community meetings
+meta_description: Keep up-to-date with what's going on in the OME community.
+---
+        <!-- begin News -->
+        <hr class="whitespace">
+        <div id="community-posts" class="row">
+{% for minute in site.minutes %}
+            <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> {{minute.date | date: "%B %d, %Y"}}</h6>
+                <h2><a href="{{ minute.url | relative_url }}">{{minute.title}}</a></h2>
+                <p class="card-caption">{{minute.intro-blurb}}</p>
+                <div class="row"></div>
+            </div>
+            <hr class="medium-8">
+{% endfor %}
+        </div>
+        <!-- end News -->
+        <hr class="whitespace">
+        <div class="row">
+            <div class="small-12 medium-8 medium-offset-2">
+                <p class="callout primary">FIXME You can find details of earlier releases in the documentation for the product you're interested in</p>
+            </div>
+        </div>
+        <hr class="invisible">
+

--- a/minutes/index.html
+++ b/minutes/index.html
@@ -8,7 +8,8 @@ meta_description: Keep up-to-date with what's going on in the OME community.
         <!-- begin News -->
         <hr class="whitespace">
         <div id="community-posts" class="row">
-{% for minute in site.minutes %}
+{% assign sorted = site.minutes | reverse %}
+{% for minute in sorted %}
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> {{minute.date | date: "%B %d, %Y"}}</h6>
                 <h2><a href="{{ minute.url | relative_url }}">{{minute.title}}</a></h2>

--- a/on-the-web/index.html
+++ b/on-the-web/index.html
@@ -53,7 +53,7 @@ meta_description: Find OME on social media and catch up on weekly minutes.
             <div class="marketing-site-content-section-block">
                 <h3 class="marketing-site-content-section-block-header">OME Team Meeting Minutes</h3>
                 <p class="marketing-site-content-section-block-subheader subheader">We meet every Tuesday at 2pm UK time (GMT or BST) to discuss the current progress of the project.</p>
-                <a href="https://drive.google.com/drive/u/0/folders/1eG-w66mDVgccZip0iU61FjhUQk07BFYs" class="button small">Read meeting minutes</a>
+                <a href="https://drive.google.com/drive/folders/1EaPl_D3PhYrF44BjJJkgs45xE5FQXvLp" class="button small">Read meeting minutes</a>
             </div>
             <!--<div class="marketing-site-content-section-block small-order-2 medium-order-1">
                 <h3 class="marketing-site-content-section-block-header">[ GDocs? ]</h3>

--- a/on-the-web/index.html
+++ b/on-the-web/index.html
@@ -5,7 +5,7 @@ meta_description: Find OME on social media and catch up on weekly minutes.
 ---
         <div class="callout large primary" id="bg-image-social" style="margin-bottom: 0rem;">
             <div class="row column text-center">
-                <h1>On the Web</h1>
+                <h1>Catch up with OME</h1>
                 <p>Follow the day-to-day activities of the OME team on the Web.</p>
             </div>
         </div>
@@ -25,7 +25,7 @@ meta_description: Find OME on social media and catch up on weekly minutes.
                         <a class="account-profile" href="https://www.twitter.com/bioformats" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_bio-formats.png" alt="@bioformats twitter profile pic"></a>
                         <div>
                             <p class="account-handle"><a href="https://www.twitter.com/bioformats" target="_blank">@bioformats</a></p>
-                            <p class="account-desc">Development status feed of coming features and release announcements.</p>
+                            <p class="account-desc">Coming features and release announcements.</p>
                         </div>
                     </div>
                     <div class="social-media-feature-section-feature bottom-left">
@@ -52,8 +52,12 @@ meta_description: Find OME on social media and catch up on weekly minutes.
             </div>
             <div class="marketing-site-content-section-block">
                 <h3 class="marketing-site-content-section-block-header">OME Team Meeting Minutes</h3>
-                <p class="marketing-site-content-section-block-subheader subheader">We meet every Tuesday at 2pm UK time (GMT or BST) to discuss the current progress of the project.</p>
-                <a href="https://drive.google.com/drive/folders/1EaPl_D3PhYrF44BjJJkgs45xE5FQXvLp" class="button small">Read meeting minutes</a>
+                <p class="marketing-site-content-section-block-subheader subheader">
+                    We meet every Tuesday at 2pm UK time (GMT or BST) to discuss the current progress of the project.
+                    Get in touch on social media or <a href="https://forum.image.sc/g/ome">image.sc</a>
+                    for a Zoom link.
+                </p>
+                <a href="{{ site.baseurl }}/minutes" class="button small">Read meeting minutes</a>
             </div>
             <!--<div class="marketing-site-content-section-block small-order-2 medium-order-1">
                 <h3 class="marketing-site-content-section-block-header">[ GDocs? ]</h3>

--- a/on-the-web/index.html
+++ b/on-the-web/index.html
@@ -46,7 +46,23 @@ meta_description: Find OME on social media and catch up on weekly minutes.
             </div>
         </section>
         <hr class="whitespace">
-        <div class="marketing-site-content-section">
+        <section class="social-media-feature-section">
+            <div class="social-media-feature-section-outer">
+                <h3 class="social-media-feature-section-headline"><i class="fa fa-user-circle-o" aria-hidden="true"></i> OME Community Meeting</h3>
+                <div class="social-media-feature-section-inner">
+                    <div class="social-media-feature-section-feature top-left">
+                        <a class="account-profile" href="{{ site.baseurl }}/minutes" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_ome.png" alt="@openmicroscopy twitter profile pic"></a>
+                        <div>
+                            <p class="account-handle"><a href="{{ site.baseurl }}/minutes" target="_blank">Community meeting minutes</a></p>
+                            <p class="account-desc">We meet every Tuesday at 2pm UK time (GMT or BST) to discuss the current progress of the project.
+                            Get in touch on social media or <a href="https://forum.image.sc/g/ome">image.sc</a>
+                            for a Zoom link.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <!--<div class="marketing-site-content-section">
             <div class="marketing-site-content-section-img">
                 <img src="{{ site.baseurl }}/img/stock/pixabay/laptop-notes.jpg" alt="community meeting notes" />
             </div>
@@ -59,7 +75,7 @@ meta_description: Find OME on social media and catch up on weekly minutes.
                 </p>
                 <a href="{{ site.baseurl }}/minutes" class="button small">Read meeting minutes</a>
             </div>
-            <!--<div class="marketing-site-content-section-block small-order-2 medium-order-1">
+            <div class="marketing-site-content-section-block small-order-2 medium-order-1">
                 <h3 class="marketing-site-content-section-block-header">[ GDocs? ]</h3>
                 <p class="marketing-site-content-section-block-subheader subheader">Content placeholder based on notes from the Trello card. What else can we link to?</p>
                 <a href="https://drive.google.com/drive/folders/0B2ytmM7Jmj58N2gzcWZ6UVJONTA" class="button small">[ CTA phrase ]</a>
@@ -67,13 +83,12 @@ meta_description: Find OME on social media and catch up on weekly minutes.
             <div class="marketing-site-content-section-img small-order-1 medium-order-2">
                 <img src="https://images.pexels.com/photos/300857/pexels-photo-300857.jpeg?h=350&auto=compress&cs=tinysrgb" alt="placeholder image" />
             </div>-->
-        </div>
         <hr class="whitespace">
         <section class="social-media-feature-section">
             <div class="social-media-feature-section-outer">
                 <h3 class="social-media-feature-section-headline"><i class="fa fa-github" aria-hidden="true"></i> Follow Us on GitHub</h3>
                 <div class="social-media-feature-section-inner">
-                    <div class="social-media-feature-section-feature">
+                    <div class="social-media-feature-section-feature top-left">
                         <a class="account-profile" href="https://github.com/openmicroscopy" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/github_ome.png" alt="@openmicroscopy github profile pic"></a>
                         <div>
                             <p class="account-handle"><a href="https://github.com/openmicroscopy" target="_blank">@openmicroscopy</a></p>

--- a/on-the-web/index.html
+++ b/on-the-web/index.html
@@ -48,10 +48,10 @@ meta_description: Find OME on social media and catch up on weekly minutes.
         <hr class="whitespace">
         <div class="marketing-site-content-section">
             <div class="marketing-site-content-section-img">
-                <img src="{{ site.baseurl }}/img/stock/pixabay/laptop-notes.jpg" alt="team meeting notes" />
+                <img src="{{ site.baseurl }}/img/stock/pixabay/laptop-notes.jpg" alt="community meeting notes" />
             </div>
             <div class="marketing-site-content-section-block">
-                <h3 class="marketing-site-content-section-block-header">OME Team Meeting Minutes</h3>
+                <h3 class="marketing-site-content-section-block-header">OME Community Meeting</h3>
                 <p class="marketing-site-content-section-block-subheader subheader">
                     We meet every Tuesday at 2pm UK time (GMT or BST) to discuss the current progress of the project.
                     Get in touch on social media or <a href="https://forum.image.sc/g/ome">image.sc</a>

--- a/support/index.html
+++ b/support/index.html
@@ -84,6 +84,16 @@ meta_description: A collection of support resources to help the OME community.
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
+                        <i class="border-red icon-red fa fa-graduation-cap fa-2x"></i>
+                        <h4>On the web</h4>
+                        <p class="card-caption">Follow us on social media or listen in to a community meeting.</p>
+                        <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">On the web</a>
+                    </div>
+                </div>
+            </div>
+            <div class="small-12 medium-4 columns">
+                <div class="card card-support">
+                    <div class="card-section">
                         <h4>Old resources</h4>
                         <p class="card-caption">We have moved to <a href="https://www.openmicroscopy.org/forums">image.sc</a> but you can still view our old discussion resources:</p>
                         <div><a href="https://www.openmicroscopy.org/community/">old forums</a></div>

--- a/support/index.html
+++ b/support/index.html
@@ -32,7 +32,7 @@ meta_description: A collection of support resources to help the OME community.
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-green icon-green fa fa-life-ring fa-2x"></i>
+                        <i class="border-green icon-green fa fa-question-circle-o fa-2x"></i>
                         <h4>OMERO User Help</h4>
                         <p class="card-caption">Workflow-based guides for getting the most out of OMERO clients.<br><br></p>
                         <a href="https://help.openmicroscopy.org/" target="_blank" class="btn-blue button small">Get Help on OMERO</a>
@@ -84,7 +84,7 @@ meta_description: A collection of support resources to help the OME community.
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
-                        <i class="border-red icon-red fa fa-graduation-cap fa-2x"></i>
+                        <i class="border-red icon-red fa fa-link fa-2x"></i>
                         <h4>On the web</h4>
                         <p class="card-caption">Follow us on social media or listen in to a community meeting.</p>
                         <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">On the web</a>

--- a/support/index.html
+++ b/support/index.html
@@ -94,11 +94,11 @@ meta_description: A collection of support resources to help the OME community.
             <div class="small-12 medium-4 columns">
                 <div class="card card-support">
                     <div class="card-section">
+                        <i class="border-black icon-black fa fa-key fa-2x"></i>
                         <h4>Old resources</h4>
                         <p class="card-caption">We have moved to <a href="https://www.openmicroscopy.org/forums">image.sc</a> but you can still view our old discussion resources:</p>
-                        <div><a href="https://www.openmicroscopy.org/community/">old forums</a></div>
-                        <div><a href="https://lists.openmicroscopy.org.uk/pipermail/ome-users/">ome-users list</a></div>
-                        <div><a href="https://lists.openmicroscopy.org.uk/pipermail/ome-devel/">ome-devel list</a></div>
+                        <div><a href="https://www.openmicroscopy.org/community/">old forums, </a><a href="https://lists.openmicroscopy.org.uk/pipermail/ome-users/">ome-users, </a>
+                        <a href="https://lists.openmicroscopy.org.uk/pipermail/ome-devel/">ome-devel</a></div>
                     </div>
                 </div>
             </div>

--- a/support/index.html
+++ b/support/index.html
@@ -86,7 +86,7 @@ meta_description: A collection of support resources to help the OME community.
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-link fa-2x"></i>
                         <h4>On the web</h4>
-                        <p class="card-caption">Follow us on social media or listen in to a community meeting.</p>
+                        <p class="card-caption">Follow us on social media or listen in to a community meeting. Zoom link on request via social media or <a href="https://forum.image.sc/g/ome">image.sc</a></p>
                         <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">On the web</a>
                     </div>
                 </div>

--- a/support/index.html
+++ b/support/index.html
@@ -85,9 +85,9 @@ meta_description: A collection of support resources to help the OME community.
                 <div class="card card-support">
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-link fa-2x"></i>
-                        <h4>On the web</h4>
-                        <p class="card-caption">Follow us on social media or listen in to a community meeting. Zoom link on request via social media or <a href="https://forum.image.sc/g/ome">image.sc</a></p>
-                        <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">On the web</a>
+                        <h4>Catch up with OME</h4>
+                        <p class="card-caption">Follow us on social media, read minutes of or listen in to an OME Team meeting.</p>
+                        <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">Catch up with OME</a>
                     </div>
                 </div>
             </div>

--- a/support/index.html
+++ b/support/index.html
@@ -86,7 +86,7 @@ meta_description: A collection of support resources to help the OME community.
                     <div class="card-section">
                         <i class="border-red icon-red fa fa-link fa-2x"></i>
                         <h4>Catch up with OME</h4>
-                        <p class="card-caption">Follow us on social media, read minutes of or listen in to an OME Team meeting.</p>
+                        <p class="card-caption">Follow us on social media, read minutes of or listen in to an OME community meeting.</p>
                         <a href="{{ site.baseurl }}/on-the-web/" class="btn-blue button small">Catch up with OME</a>
                     </div>
                 </div>


### PR DESCRIPTION
fix #402 by including more information about how to join meetings as well as making the minutes available directly from the webpage.

![Screen Shot 2020-09-30 at 08 27 15](https://user-images.githubusercontent.com/88113/94650336-c7aac500-02f6-11eb-870c-fa16b74c980b.png)


 - [x] 2020 notes
 - [x] other notes
 - [ ] review size of or replace on-the-web image
 - [ ] shrink size of /minutes text