### PR TITLE
Use GitHub openmicroscopy release page where possible

### DIFF
--- a/_posts/2020-03-25-omero-5-6-1.md
+++ b/_posts/2020-03-25-omero-5-6-1.md
@@ -49,7 +49,7 @@ in order to simplify upgrade. Full documentation for this release is available
 under <https://docs.openmicroscopy.org/omero/5.6.1/>.
 
 OMERO.server 5.6.1 is available from
-[archived downloads](https://downloads.openmicroscopy.org/omero/5.6.1/artifacts/)
+[archived downloads](https://github.com/ome/openmicroscopy/releases/tag/v5.6.1)
 and [omero-web 5.6.3](https://pypi.org/project/omero-web/5.6.3/) also
 includes security fixes. These have been tested with
 [omero-py 5.6.2](https://pypi.org/project/omero-py/5.6.2/) so we

--- a/_posts/2020-07-16-omero-5-6-2.md
+++ b/_posts/2020-07-16-omero-5-6-2.md
@@ -20,7 +20,7 @@ announcement. Full documentation for this release is available
 under <https://docs.openmicroscopy.org/omero/5.6.2/>.
 
 OMERO.server 5.6.2 is available from
-[archived downloads](https://downloads.openmicroscopy.org/omero/5.6.2/artifacts/).
+[archived downloads](https://github.com/ome/openmicroscopy/releases/tag/v5.6.2).
 [OMERO.web 5.7.0](https://pypi.org/project/omero-web/5.7.0/) and [OMERO.iviewer 0.10.0](https://pypi.org/project/omero-iviewer/0.10.0/) are both available from PyPI.
 These have been tested with
 [OMERO.py 5.7.1](https://pypi.org/project/omero-py/5.7.1/) so we

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -105,7 +105,7 @@ meta_description: Download the latest version of OMERO here.
                         <h5>Server (Ice 3.6)</h5>
                         <h6>OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">View installation guides in <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/index.html" target="_blank">System Administrator documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (260 MB)</a>
+                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (260 MB)</a>
                     </div>
                 </div>
             </div>
@@ -137,7 +137,7 @@ meta_description: Download the latest version of OMERO here.
                         <h5>Java (Ice 3.6)</h5>
                         <h6>OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">The OMERO Java documentation is available to read on the web <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/Java.html">here</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/omero/{{ site.omero.version }}/artifacts/OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (125 MB)</a>
+                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (125 MB)</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Switches OMERO.server and openmicroscopy URLs to GitHub releases where possible