### PR TITLE
DO NOT MERGE: Revert www.openmicroscopy.org CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.openmicroscopy.org

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,7 @@ markdown: kramdown
 
 url: https://ome.github.io
 repository: openmicroscopy/www.openmicroscopy.org
-baseurl: ''
-# baseurl: /www.openmicroscopy.org
+baseurl: /www.openmicroscopy.org
 
 plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
This is to ensure https://snoopycrimecop.github.io/www.openmicroscopy.org/ builds triggered by Jenkins CI continue to work (hopefully).