### PR TITLE
Add Schemas as a submodule of www.openmicroscopy.org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "_minutes"]
 	path = _minutes
 	url = https://github.com/ome/meeting-minutes
+[submodule "Schemas"]
+	path = Schemas
+	url = https://github.com/ome/schemas


### PR DESCRIPTION
Replaces https://github.com/ome/www.openmicroscopy.org/pull/286 but with the same goal i.e. re-include the published OME schemas under www.openmicroscopy.org/Schemas/ as part of the static Jekyll website.


As opposed to #286, most of the logic has been migrated to a submodule which is included in this repository (like https://github.com/ome/www.openmicroscopy.org/pull/403).

Summarizing the main features:

- https://github.com/ome/schemas/commit/3cfad445e0e781a7e3053d0b92a9e97d1d7114c9 extracts the history of the `publish` script used for generating the www.openmicroscopy.org/Schemas pages
- https://github.com/ome/schemas/commit/b93e63d01ed4f6c8a1cca5383b87e478225447d0 adds some Maven infrastructure for consuming `org.openmicroscopy:specification` and building the HTML pages
- https://github.com/ome/schemas/commit/320f4555de00e71076001bb93c6e62c40b0bdf0e adds a GitHub action to generate the /Schemas page and auto-push the changes on push to `master` - see https://github.com/ome/schemas/commit/151dac31d982597b8847b793d6dbc87d3406b4a5 for an example
- https://github.com/ome/schemas/blob/master/.github/dependabot.yml configures GitHub dependabot to open PRs on new releases of the specification/plugins - see https://github.com/ome/schemas/pull/1 followed byhttps://github.com/ome/schemas/commit/fdc888ead257b1a8dad0017075fb2e37426fc2d4 for an example of how this logic should keep the Schemas in sync with the released artifact