### PR TITLE
Checkout submodules for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Build static website
         run: ./build.sh
         env:


### PR DESCRIPTION
Note that https://www.openmicroscopy.org/minutes/ currently is empty as opposed to https://snoopycrimecop.github.io/www.openmicroscopy.org/minutes/

Thanks to June for pointing it out. Propose for immediate tagging & re-release.