### PR TITLE
Add checks for file existence

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,5 @@ docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyl
 docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/'
 
 # Test file existence
-test -f _site/Schemas/OME/2016-06/ome.xsd
-test -f _site/minutes/README.md
+test -f _site/Schemas/OME/2016-06/ome.xsd || echo "Missing schemas" && exit 1
+test -f _site/minutes/README.md || echo "Missing minutes" && exit 1

--- a/build.sh
+++ b/build.sh
@@ -8,3 +8,7 @@ docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyl
 # Report 4xx status codes except 429 errors (Too Many Requests)
 # typically sent by GitHub while linkchecking the downloads
 docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/'
+
+# Test file existence
+test -f _site/Schemas/OME/2016-06/ome.xsd
+test -f _site/minutes/README.md

--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,7 @@ docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyl
 docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/'
 
 # Test file existence
-test -f _site/Schemas/OME/2016-06/ome.xsd || echo "Missing schemas" && exit 1
-test -f _site/minutes/README.md || echo "Missing minutes" && exit 1
+echo "Checking Schemas existence"
+test -f _site/Schemas/OME/2016-06/ome.xsd
+echo "Checking meeting minutes existence"
+test -f _site/minutes/README.md


### PR DESCRIPTION
As a follow-up of #432, this adds minimal checks to the `build.sh` script to ensure at least one reference file from each submodule is in the build