### PR TITLE
Twitter links

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -u
 docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
 # Report 4xx status codes except 429 errors (Too Many Requests)
 # typically sent by GitHub while linkchecking the downloads
-docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/'
+docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/' --url-ignore "/twitter.com/"
 
 # Test file existence
 echo "Checking Schemas existence"

--- a/events/ome-community-meeting-2020/index.html
+++ b/events/ome-community-meeting-2020/index.html
@@ -25,7 +25,7 @@ title: Overview
                         <li><a href="{{ site.baseurl }}/events/ome-community-meeting-2020/workshops/">May 28 – Practical workshops</a></li>
                     </ul>
 
-                    <p class="card-caption margin-top">We hope that this structure can accommodate the schedules of different members of the community. We’ll continue to post updates here, on <a href="https://www.twitter.com/openmicroscopy" target="_blank">Twitter (@openmicroscopy)</a>, and the <a href="https://forum.image.sc/t/ome-community-meeting-may-26-28-dundee/32924/3" target="_blank">image.sc forum</a>.</p>
+                    <p class="card-caption margin-top">We hope that this structure can accommodate the schedules of different members of the community. We’ll continue to post updates here, on <a href="https://twitter.com/openmicroscopy" target="_blank">Twitter (@openmicroscopy)</a>, and the <a href="https://forum.image.sc/t/ome-community-meeting-may-26-28-dundee/32924/3" target="_blank">image.sc forum</a>.</p>
 
                     <p class="card-caption">Looking forward to “meeting” you all soon. Thanks for your continued support during these challenging times.</p>
 

--- a/on-the-web/index.html
+++ b/on-the-web/index.html
@@ -15,30 +15,30 @@ meta_description: Find OME on social media and catch up on weekly minutes.
                 <h3 class="social-media-feature-section-headline"><i class="fa fa-twitter" aria-hidden="true"></i> Follow Us on Twitter</h3>
                 <div class="social-media-feature-section-inner">
                     <div class="social-media-feature-section-feature top-left">
-                        <a class="account-profile" href="https://www.twitter.com/openmicroscopy" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_ome.png" alt="@openmicroscopy twitter profile pic"></a>
+                        <a class="account-profile" href="https://twitter.com/openmicroscopy" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_ome.png" alt="@openmicroscopy twitter profile pic"></a>
                         <div>
-                            <p class="account-handle"><a href="https://www.twitter.com/openmicroscopy" target="_blank">@openmicroscopy</a></p>
+                            <p class="account-handle"><a href="https://twitter.com/openmicroscopy" target="_blank">@openmicroscopy</a></p>
                             <p class="account-desc">Our main Twitter account for project-wide news and interest stories.</p>
                         </div>
                     </div>
                     <div class="social-media-feature-section-feature top-right">
-                        <a class="account-profile" href="https://www.twitter.com/bioformats" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_bio-formats.png" alt="@bioformats twitter profile pic"></a>
+                        <a class="account-profile" href="https://twitter.com/bioformats" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_bio-formats.png" alt="@bioformats twitter profile pic"></a>
                         <div>
-                            <p class="account-handle"><a href="https://www.twitter.com/bioformats" target="_blank">@bioformats</a></p>
+                            <p class="account-handle"><a href="https://twitter.com/bioformats" target="_blank">@bioformats</a></p>
                             <p class="account-desc">Coming features and release announcements.</p>
                         </div>
                     </div>
                     <div class="social-media-feature-section-feature bottom-left">
-                        <a href="https://www.twitter.com/idrnews" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_idr.jpg" alt="@idrnews twitter profile pic"></a>
+                        <a href="https://twitter.com/idrnews" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_idr.jpg" alt="@idrnews twitter profile pic"></a>
                         <div>
-                            <p class="account-handle"><a href="https://www.twitter.com/idrnews" target="_blank">@IDRnews</a></p>
+                            <p class="account-handle"><a href="https://twitter.com/idrnews" target="_blank">@IDRnews</a></p>
                             <p class="account-desc">Updates on IDR e.g. new data releases.</p>
                         </div>
                     </div>
                     <div class="social-media-feature-section-feature bottom-right">
-                        <a href="https://www.twitter.com/idrstatus" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_idr.jpg" alt="@idrstatus twitter profile pic"></a>
+                        <a href="https://twitter.com/idrstatus" target="_blank"><img class="account-profile-pic" src="{{ site.baseurl }}/img/social-media/twitter_idr.jpg" alt="@idrstatus twitter profile pic"></a>
                         <div>
-                            <p class="account-handle"><a href="https://www.twitter.com/idrstatus" target="_blank">@IDRstatus</a></p>
+                            <p class="account-handle"><a href="https://twitter.com/idrstatus" target="_blank">@IDRstatus</a></p>
                             <p class="account-desc">System status news for the IDR.</p>
                         </div>
                     </div>


### PR DESCRIPTION
For some still unclear reasons, the Twitter handle URLs started failing `htmlproofer` with a 400 error code. 

As this is preventing website releases, this is updating the `htmlproofer` command to ignore the Twitter URLs. I can add a follow-up issue to review.