### PR TITLE
Move Simon to the former OME members section

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -41,7 +41,7 @@ consortium:
       member_link: "http://profiles.utsouthwestern.edu/profile/139751/gaudenz-danuser.html"
       institution: "UT Southwestern"
     - member_name: "Dr Ilan Davis"
-      member_link: "http://www.ilandavis.com/home.html"
+      member_link: "https://ilandavis.com"
       institution: "University of Oxford"
     - member_name: "Mr Kevin Eliceiri"
       member_link: "https://loci.wisc.edu"

--- a/teams/index.html
+++ b/teams/index.html
@@ -19,10 +19,6 @@ swedlow_lab:
       surname: Gault
       job_title: Software Developer
       bio: "David Gault joined the OME team in August 2015 as a software developer. David lives and works from Belfast N.Ireland where he graduated with a Masters in Computer Science from Queens University Belfast. Since then he has worked as a developer across many different industries including the Office team at Microsoft, investment banking, scientific image acquisition and cloud based streaming for TV and media. In his spare time he likes to research and tinker with projects in areas such as augmented reality and natural human interfaces."
-    - firstname: Simon
-      surname: Li
-      job_title: Software Developer
-      bio: "Simon Li joined the OME as a software developer in October 2012, and is working on visual image search and automated image annotation/labelling for OMERO. He has an interdisciplinary PhD in a mix of biological image analysis, machine learning and cell biology, and has previously worked on a wide variety of projects including developing an automated subtitling system, analysing homing pigeon navigation strategies, and working on a robot sheep dog simulator. In his spare time he enjoys walking and cycling in the hills, and is considering starting a bike polo group in Dundee, or learning the bagpipes."
     - firstname: Dominik
       surname: Lindner
       job_title: Software Developer
@@ -71,6 +67,8 @@ alumni:
       githubname: rleigh-codelibre
     - fullname: Simone Leo
       githubname: simleo
+    - fullname: Simon Li
+      githubname: manics
     - fullname: Scott Littlewood
       githubname: scottlittlewood
     - fullname: Brian Loranger

--- a/teams/index.html
+++ b/teams/index.html
@@ -105,7 +105,7 @@ development_teams:
     - team_name: Danuser Lab
       link: "http://profiles.utsouthwestern.edu/profile/139751/gaudenz-danuser.html"
     - team_name: Davis Lab
-      link: "http://www.ilandavis.com/home.html"
+      link: "https://ilandavis.com"
     - team_name: Eliceiri Lab
       link: "https://loci.wisc.edu"
     - team_name: French Lab


### PR DESCRIPTION
Simon moved to a new position. Also updates the broken URL for Ilan Davis group