### PR TITLE
Add Share page with pointer to omero-guides

### DIFF
--- a/_layouts/omero-features.html
+++ b/_layouts/omero-features.html
@@ -9,6 +9,7 @@
                 <li><a href="{{ site.baseurl }}/omero/features/">NEW</a></li>
                 <li><a href="{{ site.baseurl }}/omero/features/import/">Import</a></li>
                 <li><a href="{{ site.baseurl }}/omero/features/organize/">Organize</a></li>
+                <li><a href="{{ site.baseurl }}/omero/features/share/">Share</a></li>
                 <li><a href="{{ site.baseurl }}/omero/features/view/">View</a></li>
                 <li><a href="{{ site.baseurl }}/omero/features/analyze/">Analyze</a></li>
                 <li><a href="{{ site.baseurl }}/omero/features/publish/">Publish</a></li>

--- a/omero/features/organize/index.html
+++ b/omero/features/organize/index.html
@@ -16,9 +16,6 @@ meta_description: Learn how to use manage your image data within OMERO.
             <p class="subheader">
                 View acquisition metadata, add your own annotations and use them to filter your data.
             </p>
-            <p class="subheader">
-                Share your images and collaborate with colleagues anywhere.
-            </p>
             <hr class="medium-10">
             <div class="row small-12 medium-up-3">
 
@@ -41,13 +38,6 @@ meta_description: Learn how to use manage your image data within OMERO.
                     <h4>Browse and filter images</h4>
                     <p>Browse, filter and view images remotely on cross-platform software.</p>
                     <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/annotate.html" target="_blank">View user guide</a>
-                </div>
-                <div class="omero-feature-container column text-center">
-                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_manage.svg">
-                    <h4>Permissions</h4>
-                    <p>Allows users to share data within groups and collaborate on their data.</p>
-                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html" target="_blank">View user guide</a>
-                    <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/server-permissions.html" target="_blank">View sysadmin guide</a>
                 </div>
                 <div class="omero-feature-container column text-center">
                     <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_annotate.svg">

--- a/omero/features/share/index.html
+++ b/omero/features/share/index.html
@@ -1,0 +1,37 @@
+---
+layout: omero-features
+title: OMERO Features
+feature: Share
+usergroup: omero
+redirect_from:
+  - ../omero/share/
+meta_description: Learn how to share data within OMERO.
+---
+
+        <!-- begin OMERO features -->
+        <hr class="whitespace">
+        <div class="row column text-center">
+            <h2 class="header-blue">Sharing your data in OMERO</h2>
+            <hr class="medium-10">
+            <p class="subheader">
+                Share your images and collaborate with colleagues using the permissions system.
+            </p>
+            <hr class="medium-10">
+            <div class="row small-12 medium-up-3">
+
+                <div class="omero-feature-container column text-center">
+                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_manage.svg">
+                    <h4>Permissions</h4>
+                    <p>Allows users to share data within groups and collaborate on their data.</p>
+                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html" target="_blank">View user guide</a>
+                    <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/server-permissions.html" target="_blank">View sysadmin guide</a>
+                </div>
+                <div class="omero-feature-container column text-center">
+                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_annotate.svg">
+                    <h4>Duplicate and Move the data to Share</h4>
+                    <p>Share the data accross groups using the Duplicate and Move workflow.</p>
+                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html#shares-discontinued-feature" target="_blank">View user guide</a>
+                </div>
+            </div>
+        </div>
+        <!-- end OMERO features -->

--- a/omero/features/share/index.html
+++ b/omero/features/share/index.html
@@ -25,11 +25,18 @@ meta_description: Learn how to share data within OMERO.
                     <a class="button hollow tiny" href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/server-permissions.html" target="_blank">View sysadmin guide</a>
                 </div>
                 <div class="omero-feature-container column text-center">
-                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_annotate.svg">
+                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_organize.svg">
+                    <h4>Create Zero-cost duplicates</h4>
+                    <p>Create data duplicates which do not take space to share them with colleagues.</p>
+                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html#command-line-duplicating-objects" target="_blank">View user guide</a>
+                </div>
+                <div class="omero-feature-container column text-center">
+                    <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_export-filesets.svg">
                     <h4>Duplicate and Move the data to Share</h4>
                     <p>Share the data accross groups using the Duplicate and Move workflow.</p>
-                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html#shares-discontinued-feature" target="_blank">View user guide</a>
+                    <a class="button hollow tiny" href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/data-management.html#move-data-between-groups" target="_blank">View user guide</a>
                 </div>
+
             </div>
         </div>
         <!-- end OMERO features -->

--- a/omero/features/share/index.html
+++ b/omero/features/share/index.html
@@ -3,8 +3,6 @@ layout: omero-features
 title: OMERO Features
 feature: Share
 usergroup: omero
-redirect_from:
-  - ../omero/share/
 meta_description: Learn how to share data within OMERO.
 ---
 

--- a/omero/scientists/index.html
+++ b/omero/scientists/index.html
@@ -58,12 +58,12 @@ meta_description: Learn more about OMERO for Scientists.
                 </div>
             </div>
             <div class="column">
-                <a href="{{ site.baseurl }}/omero/features/organize/">
+                <a href="{{ site.baseurl }}/omero/features/share/">
                 <i class="icon-fa-red fa fa-share fa-2x"></i>
                 </a>
                 <div class="omero-key-feature-container">
                     <h4>Share</h4>
-                    <p>Share data with collaborators or your PI via URLs</p>
+                    <p>Share data with collaborators or your PI using the Groups/Users permission system.</p>
                 </div>
             </div>
             <div class="column">


### PR DESCRIPTION
As discussed, adding the new page under Key features called Share.
This can serve as a landing page for the webclient pointer dealt with in https://github.com/ome/omero-web/pull/265#issuecomment-786658104 and https://github.com/ome/omero-web/issues/179

This landing page in turn points to the new guides paragraph Shares which is added in https://github.com/ome/omero-guide-introduction/pull/19

In this way, the webclient url would be more solid, and even if the omero-guide url changes, would not break.

cc @joshmoore @will-moore @jburel 


Btw, happy to play with the icon if the general direction is okayed here. Atm, I would claim that the icon which I reused here, although a repetition of the annotation icon, is acceptable.