### PR TITLE
Rewrite OMERO institutions page for better completeness

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -24,7 +24,7 @@ meta_description: Explore OME products in action and see them in use in labs and
         <div class="row">
             <img class="medium-3 medium-offset-1 columns" alt="OMERO for Scientists" src="{{ site.baseurl }}/img/icons/user-groups_scientists.svg">
             <div class="medium-8 columns">
-                <p>Sign up for our <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">OMERO demo server</a> to test out the functionality with your own data. If happy, <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/"> check how to start with OMERO in your institution.</a></p>
+                <p>Sign up for our <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">OMERO demo server</a> to test out the functionality with your own data. If happy, <a href="{{ site.baseurl }}/omero/institution/getting-started.html"> check how to start with OMERO in your institution.</a></p>
                 <p><a href="{{ site.baseurl }}/bio-formats/">Bio-Formats</a> lets you read image data from Java, <a href="https://imagej.net/Welcome" target="_blank">ImageJ</a>/<a href="https://fiji.sc/" target="_blank">Fiji</a>, GNU Octave/MATLAB, Python and R. If you're already using Fiji, it comes bundled with the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/index.html#using-bio-formats-with-imagej-and-fiji">Bio-Formats plugin</a> automatically.</p>
                 <hr class="invisible">
                 <p><a class="button small" href="http://qa.openmicroscopy.org.uk/registry/demo_account/">Sign up for Demo Server</a>

--- a/explore/index.html
+++ b/explore/index.html
@@ -24,7 +24,7 @@ meta_description: Explore OME products in action and see them in use in labs and
         <div class="row">
             <img class="medium-3 medium-offset-1 columns" alt="OMERO for Scientists" src="{{ site.baseurl }}/img/icons/user-groups_scientists.svg">
             <div class="medium-8 columns">
-                <p>Sign up for our <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">demo server</a> to test out the functionality with your own data.</p>
+                <p>Sign up for our <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">OMERO demo server</a> to test out the functionality with your own data. If happy, <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/"> check how to start with OMERO in your institution.</a></p>
                 <p><a href="{{ site.baseurl }}/bio-formats/">Bio-Formats</a> lets you read image data from Java, <a href="https://imagej.net/Welcome" target="_blank">ImageJ</a>/<a href="https://fiji.sc/" target="_blank">Fiji</a>, GNU Octave/MATLAB, Python and R. If you're already using Fiji, it comes bundled with the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/index.html#using-bio-formats-with-imagej-and-fiji">Bio-Formats plugin</a> automatically.</p>
                 <hr class="invisible">
                 <p><a class="button small" href="http://qa.openmicroscopy.org.uk/registry/demo_account/">Sign up for Demo Server</a>

--- a/omero/index.html
+++ b/omero/index.html
@@ -67,12 +67,13 @@ power_of_omero:
                         repository. You can <a href="{{ site.baseurl }}/omero/features/view/">view</a>, <a href="{{ site.baseurl }}/omero/features/organize/">organize</a>, <a href="{{ site.baseurl }}/omero/features/analyze/">analyze</a> and <a href="{{ site.baseurl }}/omero/features/organize/">share</a> your data from anywhere you
                         have internet access. Work with your images from a
                         desktop app (Windows, Mac or Linux), from the web or
-                        from 3rd party software. Over 140 image file formats
+                        from 3rd party software. Over 150 image file formats
                         supported, including all major microscope formats.
                     </p>
                     <br>
                     <a href="{{ site.baseurl }}/omero/downloads/" class="large button sites-button btn-red">Download Version {{ site.omero.majorversion }}</a>
                     <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/" target="_blank" class="hero-link">Read the Docs</a>
+                    <a href="{{ site.baseurl }}/omero/institution/getting-started.html" target="_blank" class="hero-link">Start with OMERO at your Institution</a>
                 </div>
             </div>
         </header>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -9,7 +9,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <hr class="whitespace">
         <div class="row column text-center">
             <h3 class="header-green">Getting Started</h3>
-            <p class="subheader">Whether you’re an experienced system administrator ready to jump straight into installing OMERO.server or a manager wondering if the OMERO platform will meet your facility’s needs, the following guides will get you started.</p>
+            <p class="subheader">Whether you’re an experienced system administrator ready to jump straight into installing OMERO.server or a manager wondering if the OMERO platform will meet your facility’s needs, this page will get you started.</p>
         </div>
         <!-- begin Benefits -->
         <hr class="whitespace">
@@ -19,26 +19,25 @@ meta_description: To help you get started installing OMERO for your institution,
         <hr>
         <div class="row">
             <div class="medium">
-                <p>OMERO runs in thousands of institutions worldwide. In this paragraph, you might get an idea why. The software is for free, but do not miss the "What is needed...." paragraph below.</p>
+                <p>A complete platform for managing your images, <a href="{{ site.baseurl }}/omero/" target="_blank">OMERO</a> has many <a href="{{ site.baseurl }}/omero/features" target="_blank">features</a> and <a href="{{ site.baseurl }}/omero/developers/" target="_blank">expansion points</a> to <a href="{{ site.baseurl }}/omero/features/analyze/" target="_blank"> integrate with your existing tools</a>. OMERO is <a href="{{ site.baseurl }}/omero/scientists/" target="_blank"> designed with scientists in mind</a> and is tried and tested in hundreds of institutions worldwide. In this section, you might get an idea what are the benefits of OMERO for your institution. 
+                </p>
+                <p>The software is for free, but do not miss the <a href="#what-is-needed">What is needed to host OMERO?</a> section below. Also [LINK TO NOTE ABOUT SUPPORT LEVELS].</p>
             </div>
             <div>
-                <h5>Image data and metadata management system</h5>
+                <h5>Selected OMERO features</h5>
                 <ul class="dev-ops-links">
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#hardware" target="_blank">Organize and annotate your image data</a></li>
-                </ul>
-                <h5>Selected features</h5>
-                <ul class="dev-ops-links">
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Publish your original image data</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Create figures for scientific papers or colleagues</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Cooperate on images</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Access and view your images remotely via internet</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-security.html" target="_blank">Analyze the images in OMERO via API.</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/view/" target="_blank">Access and view your images remotely via internet</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/share/" target="_blank">Cooperate on images with your colleagues</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/figure/" target="_blank">Create figures for scientific papers or colleagues</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/publish/" target="_blank">Publish your original image data</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/analyze/" target="_blank">Analyze the images in OMERO via API, using established third party image analysis software.</a></li>
                 </ul>
                 <h5>Read and watch about OMERO to get a better idea.</h5>
                 <ul class="dev-ops-links">
+                    <li><a href="{{ site.baseurl }}/omero/institution/" target="_blank">Further read on advantages of OMERO for your institution</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">List of OMERO features</a></li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
-                    <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">OMERO features</a></li>
                     <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
                     <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
                     <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
@@ -46,6 +45,7 @@ meta_description: To help you get started installing OMERO for your institution,
             </div>
         </div>
         <!-- end What is needed -->
+        <a id="what-is-needed"></a>
         <hr class="whitespace">
         <div class="row column text-center">
             <h3>What is needed to host OMERO?</h3>
@@ -54,7 +54,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <div class="row">
             <div class="medium">
                 <p>The resources needed for setting up, keeping and maintaining OMERO vary according to your image data sizes and quality, and the infrastructure in your institution. Nevertheless, some general hints are given here as points which you should think about and implement in your concrete case.</p>
-                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to regional groups and list of selected institutions which run OMERO below.</p>
+                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to regional groups and list of selected institutions which run OMERO in the <a href="#contacts">Key OMERO Contacts</a> section.</p>
             </div>
             <div>
                 <h5>Server hardware and environment</h5>
@@ -72,6 +72,7 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server maintenance</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server upgrades</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server configureation optimization or changes</a></li>
+                    <li>Installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps and extensions</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-security.html" target="_blank">Server security and firewalls</a></li>
                 </ul>
                 <h5>OMERO manager person(s)</h5>
@@ -82,16 +83,17 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/group-user-management.html" target="_blank">Management of Groups/Users in OMERO</a></li>
                     <li>Collating feedback from users</li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introducing new users to OMERO</a></li>
-                    <li>Liaise with system administrator for features which require server configuration changes or installation of new OMERO apps and extensions.</li>
+                    <li>Liaise with system administrator for features which require server configuration changes or installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps</a> and extensions.</li>
                     <li>According to local needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
-                    <li>Design and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible import setup for the institution.</li>
+                    <li>Design and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible <a href="{{ site.baseurl }}/omero/features/import/" target="_blank"> import setup</a> for the institution.</li>
                 </ul>
             </div>
         </div>
         <!-- end What is needed -->
+        <a id="contacts"></a>
         <hr class="whitespace">
         <div class="row column text-center">
-            <h3>Useful OMERO read, watch and contacts</h3>
+            <h3>Key OMERO contacts</h3>
         </div>
         <hr>
         <div class="row">

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -45,7 +45,8 @@ meta_description: To help you get started installing OMERO for your institution,
                 </ul>
             </div>
         </div>
-        <!-- end What is needed -->
+        <!-- end Benefits -->
+        <!-- begin What is needed -->
         <a id="what-is-needed"></a>
         <hr class="whitespace">
         <div class="row column text-center">
@@ -82,15 +83,16 @@ meta_description: To help you get started installing OMERO for your institution,
                     Typical tasks:
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html" target="_blank">Basic walkthrough</a></li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/group-user-management.html" target="_blank">Management of Groups/Users in OMERO</a></li>
-                    <li>Collating feedback from users</li>
-                    <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introducing new users to OMERO</a></li>
+                    <li>Collate feedback from users</li>
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introduce new users to OMERO</a></li>
                     <li>Liaise with server administrator for features which require server configuration changes or installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps</a> and extensions.</li>
                     <li>According to local needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
-                    <li>Design and with server administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible <a href="{{ site.baseurl }}/omero/features/import/" target="_blank"> import setup</a> for the institution.</li>
+                    <li>Design and with server administrator implement an <a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible <a href="{{ site.baseurl }}/omero/features/import/" target="_blank"> import setup</a> for the institution.</li>
                 </ul>
             </div>
         </div>
         <!-- end What is needed -->
+        <!-- begin Key OMERO contacts -->
         <a id="contacts"></a>
         <hr class="whitespace">
         <div class="row column text-center">
@@ -111,7 +113,12 @@ meta_description: To help you get started installing OMERO for your institution,
                 </ul>
             </hr>
         </div>
-        <!-- end Useful read, watch and contact -->
+        <!-- end Key OMERO contacts-->
+        <!-- begin Selected useful guides-->
+        <hr class="whitespace">
+        <div class="row column text-center">
+            <h3>Selected useful guides</h3>
+        </div>
         <hr>
         <div class="row">
             <div class="small-12 medium-4 medium-offset-2 columns">
@@ -179,6 +186,7 @@ meta_description: To help you get started installing OMERO for your institution,
                 </div>
             </div>
         </div>
+        <!-- end Selected useful guides-->
         <!-- end Getting Started -->
 
         <hr class="whitespace">

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -21,7 +21,7 @@ meta_description: To help you get started installing OMERO for your institution,
             <div class="medium">
                 <p>A complete platform for managing your images, <a href="{{ site.baseurl }}/omero/" target="_blank">OMERO</a> has many <a href="{{ site.baseurl }}/omero/features" target="_blank">features</a> and <a href="{{ site.baseurl }}/omero/developers/" target="_blank">expansion points</a> to <a href="{{ site.baseurl }}/omero/features/analyze/" target="_blank"> integrate with your existing tools</a>. OMERO is <a href="{{ site.baseurl }}/omero/scientists/" target="_blank"> designed with scientists in mind</a> and is tried and tested in hundreds of institutions worldwide. In this section, you might get an idea what are the benefits of OMERO for your institution. 
                 </p>
-                <p>The software can be downloaded for free, but do not miss the <a href="#what-is-needed">What is needed to host OMERO?</a> section below. Also [LINK TO NOTE ABOUT SUPPORT LEVELS].</p>
+                <p>The software can be downloaded for free, but do not miss the <a href="#what-is-needed">What is needed to host OMERO?</a> section below.</p>
             </div>
             <div>
                 <h5>Selected OMERO features</h5>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -24,11 +24,11 @@ meta_description: To help you get started installing OMERO for your institution,
             <div>
                 <h5>Server hardware and environment</h5>
                 <ul class="dev-ops-links">
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Hardware</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Storage</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">RAM</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">CPU</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Software dependencies</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#hardware" target="_blank">Hardware</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#storage" target="_blank">Storage</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#ram" target="_blank">RAM</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#cpu" target="_blank">CPU</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#software" target="_blank">Software dependencies</a></li>
                 </ul>
                 <h5>Server expertise person(s)</h5>
                 <ul class="dev-ops-links">

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -32,7 +32,7 @@ meta_description: To help you get started installing OMERO for your institution,
                 </ul>
                 <h5>Server expertise person(s)</h5>
                 <ul class="dev-ops-links">
-                    For the points listed here, knowledge on how to run a server on Linux OS us essebtuak. This part is very often a task of the institutional IT department.
+                    Knowledge on how to run a server on Linux OS is essential. The following items are frequent tasks for maintainers of an OMERO system:
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server installation</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server maintenance</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server upgrades</a></li>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -39,6 +39,7 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
                     <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
+                    <li><a href="{{ site.baseurl }}//explore/" target="_blank">Give OMERO a quick try</a></li>
                     <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
                     <li><a href="{{ site.baseurl }}/training/" target="_blank">Get a training session on OMERO or organize one yourself</a></li>
                 </ul>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -69,10 +69,10 @@ meta_description: To help you get started installing OMERO for your institution,
                 <h5>Server administrator(s)</h5>
                 <ul class="dev-ops-links">
                     Knowledge on how to run a server on Linux OS is essential. The following items are frequent tasks for server administrators of an OMERO system:
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server installation</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server maintenance</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server upgrades</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server configureation optimization or changes</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html#installation" target="_blank">Server installation</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html#maintenance" target="_blank">Server maintenance</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html#upgrading" target="_blank">Server upgrades</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html#optimizing-server-configuration" target="_blank">Server configureation optimization or changes</a></li>
                     <li>Installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps and extensions</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-security.html" target="_blank">Server security and firewalls</a></li>
                 </ul>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -11,6 +11,73 @@ meta_description: To help you get started installing OMERO for your institution,
             <h3 class="header-green">Getting Started</h3>
             <p class="subheader">Whether you’re an experienced system administrator ready to jump straight into installing OMERO.server or a manager wondering if the OMERO platform will meet your facility’s needs, the following guides will get you started.</p>
         </div>
+        <hr class="whitespace">
+        <div class="row column text-center">
+            <h3>What is needed to host OMERO?</h3>
+        </div>
+        <hr>
+        <div class="row">
+            <div class="medium">
+                <p>The resources needed for setting up, keeping and maintaining OMERO vary according to your image data sizes and quality, and the infrastructure in your institution. Nevertheless, some general hints are given here as points which you should think about and implement in your concrete case.</p>
+                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to OMERO regional groups [LINK]. Some reports from already existing OMERO instances are to be seen on https://www.openmicroscopy.org/events/ome-community-meeting-2020/lightning-talks/, https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/server-setup-examples.html.</p>
+            </div>
+            <div>
+                <h5>Server hardware and environment</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Hardware</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Storage</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">RAM</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">CPU</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html" target="_blank">Software dependencies</a></li>
+                </ul>
+                <h5>Server expertise person(s)</h5>
+                <ul class="dev-ops-links">
+                    For the points listed here, knowledge on how to run a server on Linux OS us essebtuak. This part is very often a task of the institutional IT department.
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server installation</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server maintenance</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server upgrades</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server configureation optimization or changes</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-security.html" target="_blank">Server security and firewalls</a></li>
+                </ul>
+                <h5>OMERO manager person(s)</h5>
+                <ul class="dev-ops-links">
+                    This person is a go-between the users of OMERO and the system administrator of the server. Very often this might be a microscopy facility manager.
+                    Typical tasks:
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html" target="_blank">Basic walkthrough</a></li>
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/group-user-management.html" target="_blank">Management of Groups/Users in OMERO</a></li>
+                    <li>Collating feedback from users</li>
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introducing new users to OMERO</a></li>
+                    <li>Liaise with system administrator for features which require server configuration changes or installation of new OMERO apps and extensions.</li>
+                    <li>According to loacl needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
+                    <li>Think through and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, designing and selecting the best possible import setup for the institution.</li>
+                </ul>
+            </div>
+        </div>
+        <!-- end What is needed -->
+        <hr class="whitespace">
+        <div class="row column text-center">
+            <h3>Useful OMERO read, watch and contacts</h3>
+        </div>
+        <hr>
+        <div class="row">
+                <h5>Read and watch</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">OMERO features</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
+                    <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
+                    <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
+                </ul>
+                <h5>Contact</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="{{ site.baseurl }}/support/" target="_blank">Main contact to OME Team is via image.sc</a></li>
+                    <li><a href="{{ site.baseurl }}/support/" target="_blank">Check other means of support on this webpage</a></li>
+                    <li>Be a member or contact your regional group</li>
+                </ul>
+            </hr>
+        </div>
+        <!-- end Useful read, watch and contact -->
         <hr>
         <div class="row">
             <div class="small-12 medium-4 medium-offset-2 columns">

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -21,7 +21,7 @@ meta_description: To help you get started installing OMERO for your institution,
             <div class="medium">
                 <p>A complete platform for managing your images, <a href="{{ site.baseurl }}/omero/" target="_blank">OMERO</a> has many <a href="{{ site.baseurl }}/omero/features" target="_blank">features</a> and <a href="{{ site.baseurl }}/omero/developers/" target="_blank">expansion points</a> to <a href="{{ site.baseurl }}/omero/features/analyze/" target="_blank"> integrate with your existing tools</a>. OMERO is <a href="{{ site.baseurl }}/omero/scientists/" target="_blank"> designed with scientists in mind</a> and is tried and tested in hundreds of institutions worldwide. In this section, you might get an idea what are the benefits of OMERO for your institution. 
                 </p>
-                <p>The software is for free, but do not miss the <a href="#what-is-needed">What is needed to host OMERO?</a> section below. Also [LINK TO NOTE ABOUT SUPPORT LEVELS].</p>
+                <p>The software can be downloaded for free, but do not miss the <a href="#what-is-needed">What is needed to host OMERO?</a> section below. Also [LINK TO NOTE ABOUT SUPPORT LEVELS].</p>
             </div>
             <div>
                 <h5>Selected OMERO features</h5>
@@ -40,7 +40,7 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
                     <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
                     <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
-                    <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
+                    <li><a href="{{ site.baseurl }}/training/" target="_blank">Get a training session on OMERO or organize one yourself</a></li>
                 </ul>
             </div>
         </div>
@@ -54,7 +54,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <div class="row">
             <div class="medium">
                 <p>The resources needed for setting up, keeping and maintaining OMERO vary according to your image data sizes and quality, and the infrastructure in your institution. Nevertheless, some general hints are given here as points which you should think about and implement in your concrete case.</p>
-                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to regional groups and list of selected institutions which run OMERO in the <a href="#contacts">Key OMERO Contacts</a> section.</p>
+                <p>You can benefit from asking your colleagues at institutions which are already running OMERO. For that, we also list some contacts to regional groups and list of selected institutions which run OMERO in the <a href="#contacts">Key OMERO Contacts</a> section.</p>
             </div>
             <div>
                 <h5>Server hardware and environment</h5>
@@ -65,9 +65,9 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#cpu" target="_blank">CPU</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#software" target="_blank">Software dependencies</a></li>
                 </ul>
-                <h5>Server expertise person(s)</h5>
+                <h5>Server administrator(s)</h5>
                 <ul class="dev-ops-links">
-                    Knowledge on how to run a server on Linux OS is essential. The following items are frequent tasks for maintainers of an OMERO system:
+                    Knowledge on how to run a server on Linux OS is essential. The following items are frequent tasks for server administrators of an OMERO system:
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server installation</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server maintenance</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Server upgrades</a></li>
@@ -77,15 +77,15 @@ meta_description: To help you get started installing OMERO for your institution,
                 </ul>
                 <h5>OMERO manager person(s)</h5>
                 <ul class="dev-ops-links">
-                    This person is a go-between the users of OMERO and the system administrator of the server. Very often this might be a microscopy facility manager.
+                    This person is a go-between the users of OMERO and the server administrator. Very often this might be a microscopy facility manager.
                     Typical tasks:
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html" target="_blank">Basic walkthrough</a></li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/introduction/docs/group-user-management.html" target="_blank">Management of Groups/Users in OMERO</a></li>
                     <li>Collating feedback from users</li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introducing new users to OMERO</a></li>
-                    <li>Liaise with system administrator for features which require server configuration changes or installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps</a> and extensions.</li>
+                    <li>Liaise with server administrator for features which require server configuration changes or installation of <a href="{{ site.baseurl }}/omero/apps/" target="_blank">OMERO Apps</a> and extensions.</li>
                     <li>According to local needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
-                    <li>Design and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible <a href="{{ site.baseurl }}/omero/features/import/" target="_blank"> import setup</a> for the institution.</li>
+                    <li>Design and with server administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible <a href="{{ site.baseurl }}/omero/features/import/" target="_blank"> import setup</a> for the institution.</li>
                 </ul>
             </div>
         </div>
@@ -99,7 +99,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <div class="row">
                 <h5>Contact OME Team</h5>
                 <ul class="dev-ops-links">
-                    <li><a href="{{ site.baseurl }}/support/" target="_blank">Main contact to OME Team is via image.sc</a></li>
+                    <li><a href="https://forum.image.sc/tag/omero" target="_blank">Main contact to OME Team is via image.sc, tag "omero"</a></li>
                     <li><a href="{{ site.baseurl }}/support/" target="_blank">Check other means of support on this webpage</a></li>
                 </ul>
                 <h5>Regional groups and examples of institutions running OMERO</h5>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -19,7 +19,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <div class="row">
             <div class="medium">
                 <p>The resources needed for setting up, keeping and maintaining OMERO vary according to your image data sizes and quality, and the infrastructure in your institution. Nevertheless, some general hints are given here as points which you should think about and implement in your concrete case.</p>
-                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to OMERO regional groups [LINK]. Some reports from already existing OMERO instances are to be seen on https://www.openmicroscopy.org/events/ome-community-meeting-2020/lightning-talks/, https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/server-setup-examples.html.</p>
+                <p>You can benefit from asking your colleagues at Institutions which are already running OMERO. For that, we also list some contacts to regional groups and list of selected institutions which run OMERO below.</p>
             </div>
             <div>
                 <h5>Server hardware and environment</h5>
@@ -69,11 +69,16 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
                     <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
                 </ul>
-                <h5>Contact</h5>
+                <h5>Contact OME Team</h5>
                 <ul class="dev-ops-links">
                     <li><a href="{{ site.baseurl }}/support/" target="_blank">Main contact to OME Team is via image.sc</a></li>
                     <li><a href="{{ site.baseurl }}/support/" target="_blank">Check other means of support on this webpage</a></li>
-                    <li>Be a member or contact your regional group</li>
+                </ul>
+                <h5>Regional groups and examples of institutions running OMERO</h5>
+                <ul class="dev-ops-links">
+                    Get in touch with your regional group to exchange experiences about OMERO from user perspective, contact or get inspired by OMERO setup in some institutions listed below.
+                    <li><a href="https://www.gerbi-gmb.de/WG6/RDM4mic" target="_blank">German BioImaging</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-setup-examples.html" target="_blank">Selected institutional OMERO deployments</a></li>
                 </ul>
             </hr>
         </div>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -14,7 +14,7 @@ meta_description: To help you get started installing OMERO for your institution,
         <!-- begin Benefits -->
         <hr class="whitespace">
         <div class="row column text-center">
-            <h3>What do I get when I install OMERO?</h3>
+            <h3>Why OMERO?</h3>
         </div>
         <hr>
         <div class="row">
@@ -32,14 +32,14 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li><a href="{{ site.baseurl }}/omero/features/publish/" target="_blank">Publish your original image data</a></li>
                     <li><a href="{{ site.baseurl }}/omero/features/analyze/" target="_blank">Analyze the images in OMERO via API, using established third party image analysis software.</a></li>
                 </ul>
-                <h5>Read and watch about OMERO to get a better idea.</h5>
+                <h5>Read and watch about OMERO or try it to get a better idea.</h5>
                 <ul class="dev-ops-links">
+                    <li><a href="{{ site.baseurl }}//explore/" target="_blank">Give OMERO a quick try</a></li>
                     <li><a href="{{ site.baseurl }}/omero/institution/" target="_blank">Further read on advantages of OMERO for your institution</a></li>
                     <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">List of OMERO features</a></li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
                     <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
                     <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
-                    <li><a href="{{ site.baseurl }}//explore/" target="_blank">Give OMERO a quick try</a></li>
                     <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
                     <li><a href="{{ site.baseurl }}/training/" target="_blank">Get a training session on OMERO or organize one yourself</a></li>
                 </ul>

--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -11,6 +11,41 @@ meta_description: To help you get started installing OMERO for your institution,
             <h3 class="header-green">Getting Started</h3>
             <p class="subheader">Whether you’re an experienced system administrator ready to jump straight into installing OMERO.server or a manager wondering if the OMERO platform will meet your facility’s needs, the following guides will get you started.</p>
         </div>
+        <!-- begin Benefits -->
+        <hr class="whitespace">
+        <div class="row column text-center">
+            <h3>What do I get when I install OMERO?</h3>
+        </div>
+        <hr>
+        <div class="row">
+            <div class="medium">
+                <p>OMERO runs in thousands of institutions worldwide. In this paragraph, you might get an idea why. The software is for free, but do not miss the "What is needed...." paragraph below.</p>
+            </div>
+            <div>
+                <h5>Image data and metadata management system</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/system-requirements.html#hardware" target="_blank">Organize and annotate your image data</a></li>
+                </ul>
+                <h5>Selected features</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Publish your original image data</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Create figures for scientific papers or colleagues</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Cooperate on images</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/index.html" target="_blank">Access and view your images remotely via internet</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/sysadmins/server-security.html" target="_blank">Analyze the images in OMERO via API.</a></li>
+                </ul>
+                <h5>Read and watch about OMERO to get a better idea.</h5>
+                <ul class="dev-ops-links">
+                    <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
+                    <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">OMERO features</a></li>
+                    <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
+                    <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
+                    <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
+                </ul>
+            </div>
+        </div>
+        <!-- end What is needed -->
         <hr class="whitespace">
         <div class="row column text-center">
             <h3>What is needed to host OMERO?</h3>
@@ -48,8 +83,8 @@ meta_description: To help you get started installing OMERO for your institution,
                     <li>Collating feedback from users</li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/example_facility_manager.html#get-users-started" target="_blank">Introducing new users to OMERO</a></li>
                     <li>Liaise with system administrator for features which require server configuration changes or installation of new OMERO apps and extensions.</li>
-                    <li>According to loacl needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
-                    <li>Think through and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, designing and selecting the best possible import setup for the institution.</li>
+                    <li>According to local needs, design and upload of new OMERO.scripts, possibly in cooperation with image analyst.</li>
+                    <li>Design and with system administrator implement an <a href="https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/import-scenarios.html" target="_blank">import pipeline </a>, selecting the best possible import setup for the institution.</li>
                 </ul>
             </div>
         </div>
@@ -60,15 +95,6 @@ meta_description: To help you get started installing OMERO for your institution,
         </div>
         <hr>
         <div class="row">
-                <h5>Read and watch</h5>
-                <ul class="dev-ops-links">
-                    <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>
-                    <li><a href="https://docs.openmicroscopy.org/omero/latest/index.html" target="_blank">OMERO documentation</a></li>
-                    <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">OMERO features</a></li>
-                    <li><a href="{{ site.baseurl }}/omero/apps/" target="_blank">List of OMERO Apps</a></li>
-                    <li><a href="https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ/videos" target="_blank">Watch videos on openmicroscopy YouTube channel</a></li>
-                    <li><a href="{{ site.baseurl }}/training/" target="_blank">See how to get a training on OMERO or organize one yourself</a></li>
-                </ul>
                 <h5>Contact OME Team</h5>
                 <ul class="dev-ops-links">
                     <li><a href="{{ site.baseurl }}/support/" target="_blank">Main contact to OME Team is via image.sc</a></li>

--- a/omero/institution/index.html
+++ b/omero/institution/index.html
@@ -15,6 +15,9 @@ meta_description: Learn more about OMERO for Institutions.
             <img class="medium-3 medium-offset-1 columns" alt="OMERO for Institutions" src="{{ site.baseurl }}/img/icons/user-groups_institutions.svg">
             <div class="medium-7 end columns">
                 <p>
+                    <a href="{{ site.baseurl }}/omero/institution/getting-started.html">Click here for all you need to know to get started with OMERO at your institution.</a>
+                </p>
+                <p>
                     With OMERO, all the image data from your facility can be
                     securely stored and managed, using group permissions and
                     user roles to allow controlled access tailored to your


### PR DESCRIPTION
This PR is a suggestion which attempts to address https://github.com/ome/www.openmicroscopy.org/issues/454

Was not sure about some points listed in https://github.com/ome/www.openmicroscopy.org/issues/454, mainly ``cost benefits`` (left them out) and the regional groups (link maybe ? @joshmoore )

Left the existing layout at the bottom of the page, as it has some additional info and nice icons.

built at https://snoopycrimecop.github.io/www.openmicroscopy.org/omero/institution/getting-started.html
also see https://snoopycrimecop.github.io/www.openmicroscopy.org/omero/ and 
https://snoopycrimecop.github.io/www.openmicroscopy.org/omero/institution/

cc @joshmoore @jburel @sbesson  

ToDo:
1. Add link https://github.com/ome/www.openmicroscopy.org/pull/462#discussion_r610493606

