### PR TITLE
Add cli-duplicate to Apps

### DIFF
--- a/omero/apps/index.html
+++ b/omero/apps/index.html
@@ -162,3 +162,17 @@ meta_description: Learn how to extend the functionality of OMERO with web or com
                 </a>
             </div>
         </div>
+        <div class="row">
+            <div class="medium-1 medium-offset-2 columns">
+                <i class="icon-fa-blue fa fa-share-alt fa-2x"></i>
+            </div>
+            <div class="omero-key-feature-container medium-7 columns end">
+                <h4>OMERO-<span class="lowercase">cli-duplicate</span></h4>
+                <p>
+                    Create data duplicates.
+                </p>
+                <a class="button hollow tiny" href="https://pypi.org/project/omero-cli-duplicate/" target="_blank">
+                    <span class="lowercase">omero-cli-duplicate</span>
+                </a>
+            </div>
+        </div>

--- a/omero/apps/index.html
+++ b/omero/apps/index.html
@@ -169,7 +169,7 @@ meta_description: Learn how to extend the functionality of OMERO with web or com
             <div class="omero-key-feature-container medium-7 columns end">
                 <h4>OMERO-<span class="lowercase">cli-duplicate</span></h4>
                 <p>
-                    Create data duplicates.
+                    Duplicate Objects in OMERO, without duplicating binary data.
                 </p>
                 <a class="button hollow tiny" href="https://pypi.org/project/omero-cli-duplicate/" target="_blank">
                     <span class="lowercase">omero-cli-duplicate</span>


### PR DESCRIPTION
Adding an obviously missing app to the list.

There are several others which could be added

  - omero-napari
  - OMERO.dropbox (not a CLI neither a Web app though, so would need a new paragraph, maybe called Server apps ?)
  - omero-signup
  - omero-cli-zarr
  - omero-roi
  - ...
 
Not sure about any of these, and so trying to go just with the duplicate in this PR - happy to be told otherwise.

