### PR TITLE
Add ORCID IDs to team JSON and webpage

### DIFF
--- a/_data/swedlowlab.json
+++ b/_data/swedlowlab.json
@@ -8,7 +8,8 @@
       "givenName": "Jason",
       "familyName": "Swedlow",
       "jobTitle": "Co-Founder",
-      "description": "Jason Swedlow earned a BA in Chemistry from Brandeis University in 1982. He performed his PhD in Biophysics with Profs D. A. Agard and J. W. Sedat, finishing in 1994. Dr Swedlow was a postdoctoral fellow at UCSF and then Harvard Medical School from 1994 and 1998, supported by a Damon Runyon Walter Winchell Cancer Research Fund Fellowship from 1995 to 1997. In 1998, Dr Swedlow established his own laboratory at the Wellcome Trust Biocentre, University of Dundee, Scotland as a Principal Investigator and Wellcome Trust Career Development Fellow. He was awarded a Wellcome Trust Senior Fellowship in 2002, and named Professor of Quantitative Cell Biology in 2007. His lab focuses on studies of mitotic and interphase chromosome structure and dynamics. He is Co-Director of the Analytical and Quantitative Microscopy Course. He is co-founder of OME (along with Peter Sorger and Ilya Goldberg)."
+      "description": "Jason Swedlow earned a BA in Chemistry from Brandeis University in 1982. He performed his PhD in Biophysics with Profs D. A. Agard and J. W. Sedat, finishing in 1994. Dr Swedlow was a postdoctoral fellow at UCSF and then Harvard Medical School from 1994 and 1998, supported by a Damon Runyon Walter Winchell Cancer Research Fund Fellowship from 1995 to 1997. In 1998, Dr Swedlow established his own laboratory at the Wellcome Trust Biocentre, University of Dundee, Scotland as a Principal Investigator and Wellcome Trust Career Development Fellow. He was awarded a Wellcome Trust Senior Fellowship in 2002, and named Professor of Quantitative Cell Biology in 2007. His lab focuses on studies of mitotic and interphase chromosome structure and dynamics. He is Co-Director of the Analytical and Quantitative Microscopy Course. He is co-founder of OME (along with Peter Sorger and Ilya Goldberg).",
+      "identifier": "https://github.com/jrswedlow"
     },
     {
       "@type": "Person",
@@ -16,7 +17,8 @@
       "givenName": "Sebastien",
       "familyName": "Besson",
       "jobTitle": "Senior Software Developer",
-      "description": "Sebastien Besson joined the OME team as a developer in March 2012. Originally trained as a physicist, he received his PhD from the Unversite Pierre at Marie Curie in Paris. He then carried out postdoctoral research at the interface between physics and biology at Harvard University. In 2011, Sebastien joined the Danuser lab to convert in-house image analysis into turn-key software packages for the cell biology community. He became part of the main Dundee team in 2015."
+      "description": "Sebastien Besson joined the OME team as a developer in March 2012. Originally trained as a physicist, he received his PhD from the Unversite Pierre at Marie Curie in Paris. He then carried out postdoctoral research at the interface between physics and biology at Harvard University. In 2011, Sebastien joined the Danuser lab to convert in-house image analysis into turn-key software packages for the cell biology community. He became part of the main Dundee team in 2015.",
+      "identifier": "https://github.com/sbesson"
     },
     {
       "@type": "Person",
@@ -24,14 +26,16 @@
       "givenName": "Jean-Marie",
       "familyName": "Burel",
       "jobTitle": "Senior Software Architect",
-      "description": "Jean-Marie Burel joined the staff of the Swedlow lab in 2003. Since then, he's been contributing to the development of OME. He received his PhD in mathematics from the University of Brest in 2000. His research interests lie in the area of harmonic maps, harmonic morphisms and geometric structure. After his PhD, he worked in a private company as developer then moved (September 2001) to Lund University, Sweden, where he held a post-doctoral research position. Jean-Marie now enjoys the muddy rugby pitches of Scotland."
+      "description": "Jean-Marie Burel joined the staff of the Swedlow lab in 2003. Since then, he's been contributing to the development of OME. He received his PhD in mathematics from the University of Brest in 2000. His research interests lie in the area of harmonic maps, harmonic morphisms and geometric structure. After his PhD, he worked in a private company as developer then moved (September 2001) to Lund University, Sweden, where he held a post-doctoral research position. Jean-Marie now enjoys the muddy rugby pitches of Scotland.",
+      "identifier": "https://github.com/jburel"
     },
     {
       "@type": "Person",
       "givenName": "David",
       "familyName": "Gault",
       "jobTitle": "Software Developer",
-      "description": "David Gault joined the OME team in August 2015 as a software developer. David lives and works from Belfast N.Ireland where he graduated with a Masters in Computer Science from Queens University Belfast. Since then he has worked as a developer across many different industries including the Office team at Microsoft, investment banking, scientific image acquisition and cloud based streaming for TV and media. In his spare time he likes to research and tinker with projects in areas such as augmented reality and natural human interfaces."
+      "description": "David Gault joined the OME team in August 2015 as a software developer. David lives and works from Belfast N.Ireland where he graduated with a Masters in Computer Science from Queens University Belfast. Since then he has worked as a developer across many different industries including the Office team at Microsoft, investment banking, scientific image acquisition and cloud based streaming for TV and media. In his spare time he likes to research and tinker with projects in areas such as augmented reality and natural human interfaces.",
+      "identifier": "https://github.com/dgault"
     },
     {
       "@type": "Person",
@@ -39,7 +43,8 @@
       "givenName": "Dominik",
       "familyName": "Lindner",
       "jobTitle": "Software Developer",
-      "description": "Dominik Lindner joined the team in Dundee as a Software Developer in February 2014. After studying Bioinformatics at the University of Applied Sciences Weihenstephan, Freising, he worked at different places as Java Software Developer with a bit of Linux system administration. His projects mostly had a bioinformatics background (analysis of multiple sequence alignments, DNA sequence optimization) with a short side trip into the world of logistics/warehousing. In his spare time he enjoys exploring Scotland's countryside on foot, on the bicycle or on the motorbike; respectively when the days are short and the weather's bad, trying to set up the ultimate Linux system."
+      "description": "Dominik Lindner joined the team in Dundee as a Software Developer in February 2014. After studying Bioinformatics at the University of Applied Sciences Weihenstephan, Freising, he worked at different places as Java Software Developer with a bit of Linux system administration. His projects mostly had a bioinformatics background (analysis of multiple sequence alignments, DNA sequence optimization) with a short side trip into the world of logistics/warehousing. In his spare time he enjoys exploring Scotland's countryside on foot, on the bicycle or on the motorbike; respectively when the days are short and the weather's bad, trying to set up the ultimate Linux system.",
+      "identifier": "https://github.com/dgault"
     },
     {
       "@type": "Person",
@@ -54,7 +59,8 @@
       "givenName": "Josh",
       "familyName": "Moore",
       "jobTitle": "Senior Software Architect",
-      "description": "Josh Moore is an American developer living in Walluf, Germany, with his wife and two kids. With a background in machine learning and distributed computing, Josh began work on the OMERO Java server in the Spring of 2005 as part of the Swedlow Lab, after evaluating use of the OME Perl server for the Mitocheck project while in the iBios group at the DKFZ, Heidelberg, Germany. Before that he was a German-language pre-school teacher at a Montessori school in Alabama, of all things. He's a lisp-loving, Aikido-practicing, vegan with interests in RDF, HDF, and various other three letter acronyms."
+      "description": "Josh Moore is an American developer living in Walluf, Germany, with his wife and two kids. With a background in machine learning and distributed computing, Josh began work on the OMERO Java server in the Spring of 2005 as part of the Swedlow Lab, after evaluating use of the OME Perl server for the Mitocheck project while in the iBios group at the DKFZ, Heidelberg, Germany. Before that he was a German-language pre-school teacher at a Montessori school in Alabama, of all things. He's a lisp-loving, Aikido-practicing, vegan with interests in RDF, HDF, and various other three letter acronyms.",
+      "identifier": "https://github.com/joshmoore"
     },
     {
       "@type": "Person",
@@ -62,14 +68,16 @@
       "givenName": "Will",
       "familyName": "Moore",
       "jobTitle": "Software Developer",
-      "description": "Will Moore came to Dundee as a cell biologist to do his PhD and then joined Jason's lab as a post-doc in 2003. Having got interested in the OME project from a user's point of view, he decided on a change of scene and left the lab to do an MSc in Applied Computing at Dundee University's School of Computing. He returned to the Swedlow lab for his MSc project. His goal was to make it easier for biologists to record their experimental metadata in a digital form. This was the start of the OMERO.editor development, which continued when he joined the lab as a developer in October 2007. His other interests include mountaineering, sailing and motorbiking."
+      "description": "Will Moore came to Dundee as a cell biologist to do his PhD and then joined Jason's lab as a post-doc in 2003. Having got interested in the OME project from a user's point of view, he decided on a change of scene and left the lab to do an MSc in Applied Computing at Dundee University's School of Computing. He returned to the Swedlow lab for his MSc project. His goal was to make it easier for biologists to record their experimental metadata in a digital form. This was the start of the OMERO.editor development, which continued when he joined the lab as a developer in October 2007. His other interests include mountaineering, sailing and motorbiking.",
+      "identifier": "https://github.com/will-moore"
     },
     {
       "@type": "Person",
       "givenName": "Petr",
       "familyName": "Walczysko",
       "jobTitle": "QA Software Sepcialist",
-      "description": "Petr Walczysko joined the OME project in October 2012 as a software specialist for testing and quality assurance. He studied at Charles University of Prague where he received Master of Science degree in Physics and the University of Freiburg in Germany where he received PhD in Biology. Throughout his PhD studies and his further career as a researcher he was intensively using conventional, confocal and multiphoton fluorescence microscopy applications on biological systems. He was adapting these optical microscopy techniques for particular biological problems, and also worked on the subsequent image analysis of microscopic images in a range of image analysis programs. He enjoys yoga, reading and chess."
+      "description": "Petr Walczysko joined the OME project in October 2012 as a software specialist for testing and quality assurance. He studied at Charles University of Prague where he received Master of Science degree in Physics and the University of Freiburg in Germany where he received PhD in Biology. Throughout his PhD studies and his further career as a researcher he was intensively using conventional, confocal and multiphoton fluorescence microscopy applications on biological systems. He was adapting these optical microscopy techniques for particular biological problems, and also worked on the subsequent image analysis of microscopic images in a range of image analysis programs. He enjoys yoga, reading and chess.",
+      "identifier": "https://github.com/pwalczysko"
     },
     {
       "@type": "Person",
@@ -77,7 +85,8 @@
       "givenName": "Frances",
       "familyName": "Wong",
       "jobTitle": "Curator",
-      "description": "Frances Wong joined the OME team in September 2018 as a curator. She received her PhD in Developmental Biology from the University of Edinburgh. She then carried out post-doctoral research in molecular biology, genetics, genomics, neuroscience and biomedical imaging. She has also worked on atlas-based gene expression databases and created new online scientific resources."
+      "description": "Frances Wong joined the OME team in September 2018 as a curator. She received her PhD in Developmental Biology from the University of Edinburgh. She then carried out post-doctoral research in molecular biology, genetics, genomics, neuroscience and biomedical imaging. She has also worked on atlas-based gene expression databases and created new online scientific resources.",
+      "identifier": "https://github.com/francesw"
     }
   ],
   "alumni": [

--- a/_data/swedlowlab.json
+++ b/_data/swedlowlab.json
@@ -4,30 +4,36 @@
   "member": [
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0002-2198-1958",
       "givenName": "Jason",
       "familyName": "Swedlow",
       "jobTitle": "Co-Founder",
       "description": "Jason Swedlow earned a BA in Chemistry from Brandeis University in 1982. He performed his PhD in Biophysics with Profs D. A. Agard and J. W. Sedat, finishing in 1994. Dr Swedlow was a postdoctoral fellow at UCSF and then Harvard Medical School from 1994 and 1998, supported by a Damon Runyon Walter Winchell Cancer Research Fund Fellowship from 1995 to 1997. In 1998, Dr Swedlow established his own laboratory at the Wellcome Trust Biocentre, University of Dundee, Scotland as a Principal Investigator and Wellcome Trust Career Development Fellow. He was awarded a Wellcome Trust Senior Fellowship in 2002, and named Professor of Quantitative Cell Biology in 2007. His lab focuses on studies of mitotic and interphase chromosome structure and dynamics. He is Co-Director of the Analytical and Quantitative Microscopy Course. He is co-founder of OME (along with Peter Sorger and Ilya Goldberg).",
-      "identifier": "https://github.com/jrswedlow"
+      "sameAs": [
+        "https://orcid.org/0000-0002-2198-1958",
+        "https://github.com/jrswedlow"
+      ]
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0001-8783-1429",
       "givenName": "Sebastien",
       "familyName": "Besson",
       "jobTitle": "Senior Software Developer",
       "description": "Sebastien Besson joined the OME team as a developer in March 2012. Originally trained as a physicist, he received his PhD from the Unversite Pierre at Marie Curie in Paris. He then carried out postdoctoral research at the interface between physics and biology at Harvard University. In 2011, Sebastien joined the Danuser lab to convert in-house image analysis into turn-key software packages for the cell biology community. He became part of the main Dundee team in 2015.",
-      "identifier": "https://github.com/sbesson"
+      "sameAs": [
+        "https://orcid.org/0000-0001-8783-1429",
+        "https://github.com/sbesson"
+      ]
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0002-1789-1861",
       "givenName": "Jean-Marie",
       "familyName": "Burel",
       "jobTitle": "Senior Software Architect",
       "description": "Jean-Marie Burel joined the staff of the Swedlow lab in 2003. Since then, he's been contributing to the development of OME. He received his PhD in mathematics from the University of Brest in 2000. His research interests lie in the area of harmonic maps, harmonic morphisms and geometric structure. After his PhD, he worked in a private company as developer then moved (September 2001) to Lund University, Sweden, where he held a post-doctoral research position. Jean-Marie now enjoys the muddy rugby pitches of Scotland.",
-      "identifier": "https://github.com/jburel"
+      "sameAs": [
+        "https://orcid.org/0000-0002-1789-1861",
+        "https://github.com/jburel"
+      ]
     },
     {
       "@type": "Person",
@@ -35,16 +41,20 @@
       "familyName": "Gault",
       "jobTitle": "Software Developer",
       "description": "David Gault joined the OME team in August 2015 as a software developer. David lives and works from Belfast N.Ireland where he graduated with a Masters in Computer Science from Queens University Belfast. Since then he has worked as a developer across many different industries including the Office team at Microsoft, investment banking, scientific image acquisition and cloud based streaming for TV and media. In his spare time he likes to research and tinker with projects in areas such as augmented reality and natural human interfaces.",
-      "identifier": "https://github.com/dgault"
+      "sameAs": [
+        "https://github.com/dgault"
+      ]
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0001-8038-1250",
       "givenName": "Dominik",
       "familyName": "Lindner",
       "jobTitle": "Software Developer",
       "description": "Dominik Lindner joined the team in Dundee as a Software Developer in February 2014. After studying Bioinformatics at the University of Applied Sciences Weihenstephan, Freising, he worked at different places as Java Software Developer with a bit of Linux system administration. His projects mostly had a bioinformatics background (analysis of multiple sequence alignments, DNA sequence optimization) with a short side trip into the world of logistics/warehousing. In his spare time he enjoys exploring Scotland's countryside on foot, on the bicycle or on the motorbike; respectively when the days are short and the weather's bad, trying to set up the ultimate Linux system.",
-      "identifier": "https://github.com/dgault"
+      "sameAs": [
+        "https://orcid.org/0000-0001-8038-1250",
+        "https://github.com/dominikl"
+      ]
     },
     {
       "@type": "Person",
@@ -55,21 +65,25 @@
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0003-4028-811x",
       "givenName": "Josh",
       "familyName": "Moore",
       "jobTitle": "Senior Software Architect",
       "description": "Josh Moore is an American developer living in Walluf, Germany, with his wife and two kids. With a background in machine learning and distributed computing, Josh began work on the OMERO Java server in the Spring of 2005 as part of the Swedlow Lab, after evaluating use of the OME Perl server for the Mitocheck project while in the iBios group at the DKFZ, Heidelberg, Germany. Before that he was a German-language pre-school teacher at a Montessori school in Alabama, of all things. He's a lisp-loving, Aikido-practicing, vegan with interests in RDF, HDF, and various other three letter acronyms.",
-      "identifier": "https://github.com/joshmoore"
+      "sameAs": [
+        "https://orcid.org/0000-0003-4028-811x",
+        "https://github.com/joshmoore"
+      ]
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0002-7264-8338",
       "givenName": "Will",
       "familyName": "Moore",
       "jobTitle": "Software Developer",
       "description": "Will Moore came to Dundee as a cell biologist to do his PhD and then joined Jason's lab as a post-doc in 2003. Having got interested in the OME project from a user's point of view, he decided on a change of scene and left the lab to do an MSc in Applied Computing at Dundee University's School of Computing. He returned to the Swedlow lab for his MSc project. His goal was to make it easier for biologists to record their experimental metadata in a digital form. This was the start of the OMERO.editor development, which continued when he joined the lab as a developer in October 2007. His other interests include mountaineering, sailing and motorbiking.",
-      "identifier": "https://github.com/will-moore"
+      "sameAs": [
+         "https://orcid.org/0000-0002-7264-8338",
+         "https://github.com/will-moore"
+      ]
     },
     {
       "@type": "Person",
@@ -77,48 +91,50 @@
       "familyName": "Walczysko",
       "jobTitle": "QA Software Sepcialist",
       "description": "Petr Walczysko joined the OME project in October 2012 as a software specialist for testing and quality assurance. He studied at Charles University of Prague where he received Master of Science degree in Physics and the University of Freiburg in Germany where he received PhD in Biology. Throughout his PhD studies and his further career as a researcher he was intensively using conventional, confocal and multiphoton fluorescence microscopy applications on biological systems. He was adapting these optical microscopy techniques for particular biological problems, and also worked on the subsequent image analysis of microscopic images in a range of image analysis programs. He enjoys yoga, reading and chess.",
-      "identifier": "https://github.com/pwalczysko"
+      "sameAs": "https://github.com/pwalczysko"
     },
     {
       "@type": "Person",
-      "@id": "https://orcid.org/0000-0001-7397-8251",
       "givenName": "Frances",
       "familyName": "Wong",
       "jobTitle": "Curator",
       "description": "Frances Wong joined the OME team in September 2018 as a curator. She received her PhD in Developmental Biology from the University of Edinburgh. She then carried out post-doctoral research in molecular biology, genetics, genomics, neuroscience and biomedical imaging. She has also worked on atlas-based gene expression databases and created new online scientific resources.",
-      "identifier": "https://github.com/francesw"
+      "sameAs": [
+          "https://orcid.org/0000-0001-7397-8251",
+          "https://github.com/francesw"
+      ]
     }
   ],
   "alumni": [
     {
       "@type": "Person",
       "name": "Chris Allan",
-      "identifier": "https://github.com/chris-allan"
+      "sameAs": "https://github.com/chris-allan"
     },
     {
       "@type": "Person",
       "name": "Colin Blackburn",
-      "identifier": "https://github.com/ximenesuk"
+      "sameAs": "https://github.com/ximenesuk"
     },
     {
       "@type": "Person",
       "name": "Mark Carroll",
-      "identifier": "https://github.com/mtbc"
+      "sameAs": "https://github.com/mtbc"
     },
     {
       "@type": "Person",
       "name": "Andrea Falconi",
-      "identifier": "https://github.com/c0c0n3"
+      "sameAs": "https://github.com/c0c0n3"
     },
     {
       "@type": "Person",
       "name": "Gus Ferguson",
-      "identifier": "https://github.com/gusferguson"
+      "sameAs": "https://github.com/gusferguson"
     },
     {
       "@type": "Person",
       "name": "Helen Flynn",
-      "identifier": "https://github.com/hflynn"
+      "sameAs": "https://github.com/hflynn"
     },
     {
       "@type": "Person",
@@ -135,32 +151,32 @@
     {
       "@type": "Person",
       "name": "Kenny Gillen",
-      "identifier": "https://github.com/kennethgillen"
+      "sameAs": "https://github.com/kennethgillen"
     },
     {
       "@type": "Person",
       "name": "Riad Gozim",
-      "identifier": "https://github.com/rgozim"
+      "sameAs": "https://github.com/rgozim"
     },
     {
       "@type": "Person",
       "name": "Roger Leigh",
-      "identifier": "https://github.com/rleigh-codelibre"
+      "sameAs": "https://github.com/rleigh-codelibre"
     },
     {
       "@type": "Person",
       "name": "Simone Leo",
-      "identifier": "https://github.com/simleo"
+      "sameAs": "https://github.com/simleo"
     },
     {
       "@type": "Person",
       "name": "Simon Li",
-      "identifier": "https://github.com/manics"
+      "sameAs": "https://github.com/manics"
     },
     {
       "@type": "Person",
       "name": "Scott Littlewood",
-      "identifier": "https://github.com/scottlittlewood"
+      "sameAs": "https://github.com/scottlittlewood"
     },
     {
       "@type": "Person",
@@ -177,17 +193,17 @@
     {
       "@type": "Person",
       "name": "Andrew Patterson",
-      "identifier": "https://github.com/qidane"
+      "sameAs": "https://github.com/qidane"
     },
     {
       "@type": "Person",
       "name": "Blazej Pindelski",
-      "identifier": "https://github.com/bpindelski"
+      "sameAs": "https://github.com/bpindelski"
     },
     {
       "@type": "Person",
       "name": "Balaji Ramalingam",
-      "identifier": "https://github.com/bramalingam"
+      "sameAs": "https://github.com/bramalingam"
     },
     {
       "@type": "Person",
@@ -196,7 +212,7 @@
     {
       "@type": "Person",
       "name": "Aleksandra Tarkowska",
-      "identifier": "https://github.com/olatarkowska"
+      "sameAs": "https://github.com/olatarkowska"
     },
     {
       "@type": "Person",
@@ -205,17 +221,17 @@
     {
       "@type": "Person",
       "name": "Harald Waxenegger",
-      "identifier": "https://github.com/waxenegger"
+      "sameAs": "https://github.com/waxenegger"
     },
     {
       "@type": "Person",
       "name": "Simon Wells",
-      "identifier": "https://github.com/siwells"
+      "sameAs": "https://github.com/siwells"
     },
     {
       "@type": "Person",
       "name": "Eleanor Williams",
-      "identifier": "https://github.com/eleanorwilliams"
+      "sameAs": "https://github.com/eleanorwilliams"
     },
     {
       "@type": "Person",

--- a/_data/swedlowlab.json
+++ b/_data/swedlowlab.json
@@ -4,6 +4,7 @@
   "member": [
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0002-2198-1958",
       "givenName": "Jason",
       "familyName": "Swedlow",
       "jobTitle": "Co-Founder",
@@ -11,6 +12,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0001-8783-1429",
       "givenName": "Sebastien",
       "familyName": "Besson",
       "jobTitle": "Senior Software Developer",
@@ -18,6 +20,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0002-1789-1861",
       "givenName": "Jean-Marie",
       "familyName": "Burel",
       "jobTitle": "Senior Software Architect",
@@ -32,6 +35,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0001-8038-1250",
       "givenName": "Dominik",
       "familyName": "Lindner",
       "jobTitle": "Software Developer",
@@ -46,6 +50,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0003-4028-811x",
       "givenName": "Josh",
       "familyName": "Moore",
       "jobTitle": "Senior Software Architect",
@@ -53,6 +58,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0002-7264-8338",
       "givenName": "Will",
       "familyName": "Moore",
       "jobTitle": "Software Developer",
@@ -67,6 +73,7 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0001-7397-8251",
       "givenName": "Frances",
       "familyName": "Wong",
       "jobTitle": "Curator",

--- a/img/logos/3rd-party_orcid.svg
+++ b/img/logos/3rd-party_orcid.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#A6CE39;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>

--- a/teams/index.html
+++ b/teams/index.html
@@ -67,7 +67,15 @@ schemadotorg: swedlowlab
                 <div class="column">
                     <a class="team-member" data-open="modal{{ forloop.index }}">
                         <img class="thumbnail" alt="photo of {{ member.givenName }} {{ member.familyName }}" src="{{ site.baseurl }}/img/team/{{ member.givenName | downcase }}_{{ member.familyName | downcase }}.jpg">
-                        <h5>{{ member.givenName }} {{ member.familyName }}</h5>
+                        <h5>{{ member.givenName }} {{ member.familyName }}
+                        {% if member['@id'] %}
+                        <a href="{{ member['@id'] }}">
+                            <img alt="ORCID logo"
+                             src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png"
+                             width="16" height="16" />
+                        </a>
+                        {% endif %}
+                     </h5>
                         <p class="job-title">{{ member.jobTitle }}</p>
                         <span class="bio-link tiny button hollow">Read Bio</span>
                     </a>

--- a/teams/index.html
+++ b/teams/index.html
@@ -65,20 +65,25 @@ schemadotorg: swedlowlab
             <div class="row small-up-2 medium-up-3 large-up-6 text-center" id="team-swedlow">
                 {% for member in site.data.swedlowlab.member %}
                 <div class="column">
-                    <a class="team-member" data-open="modal{{ forloop.index }}">
                         <img class="thumbnail" alt="photo of {{ member.givenName }} {{ member.familyName }}" src="{{ site.baseurl }}/img/team/{{ member.givenName | downcase }}_{{ member.familyName | downcase }}.jpg">
-                        <h5>{{ member.givenName }} {{ member.familyName }}
+                        <h5>{{ member.givenName }} {{ member.familyName }}</h5>
+                        <a class="team-member" data-open="modal{{ forloop.index }}">
+                            <span class="bio-link tiny button hollow">Read Bio</span>
+                        </a>
+                        <p class="job-title">{{ member.jobTitle }}
                         {% if member['@id'] %}
                         <a href="{{ member['@id'] }}">
                             <img alt="ORCID logo"
-                             src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png"
+                             src="{{ site.baseurl }}/img/logos/3rd-party_orcid.svg"
                              width="16" height="16" />
                         </a>
                         {% endif %}
-                     </h5>
-                        <p class="job-title">{{ member.jobTitle }}</p>
-                        <span class="bio-link tiny button hollow">Read Bio</span>
-                    </a>
+                        {% if member.identifier %}
+                        <a href="{{ member.identifier }}" target="_blank"><img src="{{ site.baseurl }}/img/logos/3rd-party-GitHub-Mark-32px.png" width="16" height="16" alt="GitHub Logo" /></a>
+                        {% endif %}
+                        </p>
+
+
                     <div class="reveal" id="modal{{ forloop.index }}" data-reveal>
                       <h4 class="text-center">{{ member.givenName }} {{ member.familyName }}</h4>
                       <p class="job-title">{{ member.jobTitle }}</p>

--- a/teams/index.html
+++ b/teams/index.html
@@ -71,16 +71,17 @@ schemadotorg: swedlowlab
                             <span class="bio-link tiny button hollow">Read Bio</span>
                         </a>
                         <p class="job-title">{{ member.jobTitle }}
-                        {% if member['@id'] %}
-                        <a href="{{ member['@id'] }}">
+                        {% for sameAs in member.sameAs %}
+                        {% if sameAs contains "orcid.org" %}
+                        <a href="{{ sameAs }}">
                             <img alt="ORCID logo"
                              src="{{ site.baseurl }}/img/logos/3rd-party_orcid.svg"
                              width="16" height="16" />
                         </a>
+                        {% elsif sameAs contains "github.com" %}
+                        <a href="{{ sameAs }}" target="_blank"><img src="{{ site.baseurl }}/img/logos/3rd-party-GitHub-Mark-32px.png" width="16" height="16" alt="GitHub Logo" /></a>
                         {% endif %}
-                        {% if member.identifier %}
-                        <a href="{{ member.identifier }}" target="_blank"><img src="{{ site.baseurl }}/img/logos/3rd-party-GitHub-Mark-32px.png" width="16" height="16" alt="GitHub Logo" /></a>
-                        {% endif %}
+                        {% endfor %}
                         </p>
 
 
@@ -130,9 +131,17 @@ schemadotorg: swedlowlab
                 {% for alumni in site.data.swedlowlab.alumni %}
                 <div class="large-expand columns">
                 {{ alumni.name }}
-                {% if alumni.identifier %}
-                <a href="{{ alumni.identifier }}" target="_blank"><img src="{{ site.baseurl }}/img/logos/3rd-party-GitHub-Mark-32px.png" width="16" height="16" alt="GitHub Logo" /></a>
+                {% for sameAs in alumni.sameAs %}
+                {% if sameAs contains "orcid.org" %}
+                <a href="{{ sameAs }}">
+                    <img alt="ORCID logo"
+                     src="{{ site.baseurl }}/img/logos/3rd-party_orcid.svg"
+                     width="16" height="16" />
+                </a>
+                {% elsif sameAs contains "github.com" %}
+                <a href="{{ sameAs }}" target="_blank"><img src="{{ site.baseurl }}/img/logos/3rd-party-GitHub-Mark-32px.png" width="16" height="16" alt="GitHub Logo" /></a>
                 {% endif %}
+                {% endfor %}
                 </div>
                 {% endfor %}
 


### PR DESCRIPTION
As ORCIDs are becoming an authoritative source of identification especially in the academic world, this contains the necessary changes to:

- add the ORCID IDs of the team to the schema.org JSON+LD as `@id` similarly to other projects - https://www.researchobject.org/ro-crate/1.1/contextual-entities.html#people
- add an inline ORCID iD (see https://info.orcid.org/brand-guidelines/#orcid-logos-and-icons) to the teams page