### PR TITLE
Additional event metadata

### DIFF
--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -3,6 +3,7 @@
   "@context": "https://schema.org",
   "@type": "Event",
   "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+  "eventStatus": "https://schema.org/EventScheduled",
   "location": {
     "@type": "VirtualLocation",
     "url": "TBD"
@@ -51,6 +52,7 @@
       "alternateName": "Day 1",
       "url": "/events/ome-community-meeting-2021/day1/",
       "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+      "eventStatus": "https://schema.org/EventScheduled",
       "startDate": "2021-06-08T10:00+01:00",
       "endDate": "2021-06-08T20:00+01:00",
       "location": {
@@ -72,6 +74,8 @@
         {
           "@type": "Event",
           "name": "Introduction",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-08T10:00+01:00",
           "endDate": "2021-06-08T11:00+01:00",
           "location": {
@@ -82,6 +86,8 @@
         {
           "@type": "Event",
           "name": "Demos",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-08T11:00+01:00",
           "endDate": "2021-06-08T14:00+01:00",
           "location": {
@@ -93,6 +99,8 @@
           "@type": "Event",
           "name": "Keynote Lecture",
           "description": "Title TBC",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-08T16:00+01:00",
           "endDate": "2021-06-08T17:00+01:00",
           "performer": [
@@ -113,6 +121,8 @@
         {
           "@type": "Event",
           "name": "Demos",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-08T17:00+01:00",
           "endDate": "2021-06-08T20:00+01:00",
           "location": {
@@ -128,6 +138,7 @@
       "alternateName": "Day 2",
       "url": "/events/ome-community-meeting-2021/day2/",
       "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+      "eventStatus": "https://schema.org/EventScheduled",
       "description": "The Research Data Management (RDM) day aims to cover (and perhaps answer) a range of pre-publication struggles, from structuring FAIR meta-/data through the search for insights and sharing those with others, all in preparation for day 3 -- public resources.",
       "startDate": "2021-06-09T10:00+01:00",
       "endDate": "2021-06-09T19:00+01:00",
@@ -177,6 +188,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T10:00+01:00",
           "endDate": "2021-06-09T11:00+01:00",
           "location": {
@@ -187,6 +200,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T11:00+01:00",
           "endDate": "2021-06-09T12:00+01:00",
           "location": {
@@ -197,6 +212,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T12:00+01:00",
           "endDate": "2021-06-09T13:00+01:00",
           "location": {
@@ -207,6 +224,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T16:00+01:00",
           "endDate": "2021-06-09T17:00+01:00",
           "location": {
@@ -217,6 +236,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T17:00+01:00",
           "endDate": "2021-06-09T18:00+01:00",
           "location": {
@@ -227,6 +248,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T18:00+01:00",
           "endDate": "2021-06-09T19:00+01:00",
           "location": {
@@ -242,6 +265,7 @@
       "alternateName": "Day 3",
       "url": "/events/ome-community-meeting-2021/day3/",
       "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+      "eventStatus": "https://schema.org/EventScheduled",
       "description": "TBD",
       "startDate": "2021-06-10T10:00+01:00",
       "endDate": "2021-06-10T19:00+01:00",
@@ -292,6 +316,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T10:00+01:00",
           "endDate": "2021-06-10T11:00+01:00",
           "location": {
@@ -302,6 +328,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T11:00+01:00",
           "endDate": "2021-06-10T12:00+01:00",
           "location": {
@@ -312,6 +340,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T12:00+01:00",
           "endDate": "2021-06-10T13:00+01:00",
           "location": {
@@ -322,6 +352,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T16:00+01:00",
           "endDate": "2021-06-10T17:00+01:00",
           "location": {
@@ -332,6 +364,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T17:00+01:00",
           "endDate": "2021-06-10T18:00+01:00",
           "location": {
@@ -342,6 +376,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T18:00+01:00",
           "endDate": "2021-06-10T19:00+01:00",
           "location": {
@@ -359,6 +395,7 @@
       "description": "TBD",
       "url": "/events/ome-community-meeting-2021/day4/",
       "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+      "eventStatus": "https://schema.org/EventScheduled",
       "startDate": "2021-06-11T10:00+01:00",
       "endDate": "2021-06-11T19:00+01:00",
       "location": {
@@ -416,6 +453,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T10:00+01:00",
           "endDate": "2021-06-11T11:00+01:00",
           "location": {
@@ -426,6 +465,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T11:00+01:00",
           "endDate": "2021-06-11T12:00+01:00",
           "location": {
@@ -436,6 +477,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T12:00+01:00",
           "endDate": "2021-06-11T13:00+01:00",
           "location": {
@@ -446,6 +489,8 @@
         {
           "@type": "Event",
           "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T16:00+01:00",
           "endDate": "2021-06-11T17:00+01:00",
           "location": {
@@ -456,6 +501,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T17:00+01:00",
           "endDate": "2021-06-11T18:00+01:00",
           "location": {
@@ -466,6 +513,8 @@
         {
           "@type": "Event",
           "name": "Workshop",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T18:00+01:00",
           "endDate": "2021-06-11T19:00+01:00",
           "location": {

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -146,6 +146,16 @@
         "@type": "VirtualLocation",
         "url": "TBD"
       },
+      "organizer": [
+        {
+          "@type": "Person",
+          "name": "Josh Moore",
+          "affiliation": {
+            "@type": "Organization",
+            "name": "University of Dundee"
+          }
+        }
+      ],
       "performer": [
         {
           "@type": "Person",
@@ -273,6 +283,16 @@
         "@type": "VirtualLocation",
         "url": "TBD"
       },
+      "organizer": [
+        {
+          "@type": "Person",
+          "name": "Sébastien Besson",
+          "affiliation": {
+            "@type": "Organization",
+            "name": "University of Dundee"
+          }
+        }
+      ],
       "performer": [
         {
           "@type": "Person",
@@ -402,6 +422,16 @@
         "@type": "VirtualLocation",
         "url": "TBD"
       },
+      "organizer": [
+        {
+          "@type": "Person",
+          "name": "Jean-Marie Burel",
+          "affiliation": {
+            "@type": "Organization",
+            "name": "University of Dundee"
+          }
+        }
+      ],
       "performer": [
         {
           "@type": "Person",

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -11,6 +11,18 @@
   "name": "2021 OME Community meeting",
   "startDate": "2021-06-08T10:00+01:00",
   "endDate": "2021-06-11T19:00+01:00",
+  "offers": [
+    {
+      "@type": "Offer",
+      "name": "Registration",
+      "availabilityStarts": "2021-05-03",
+      "availabilityEnds": "2021-06-03",
+      "priceCurrency": "GBP",
+      "price": 0,
+      "url": "TBD",
+      "availability": "InStock"
+    }
+  ],
   "organizer": [
     {
       "@type": "Person",

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -1,7 +1,7 @@
 {
-  "@id": "https://www.openmicroscopy.org/events/ome-community-meeting-2021/",
   "@context": "https://schema.org",
   "@type": "Event",
+  "url": "https://www.openmicroscopy.org/events/ome-community-meeting-2021/",
   "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
   "eventStatus": "https://schema.org/EventScheduled",
   "location": {

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -18,7 +18,8 @@
       "affiliation": {
         "@type": "Organization",
         "name": "University of Dundee"
-      }
+      },
+      "url": "https://www.openmicroscopy.org/teams/"
     },
     {
       "@type": "Person",
@@ -26,15 +27,17 @@
       "affiliation": {
         "@type": "Organization",
         "name": "University of Dundee"
-      }
+      },
+      "url": "https://www.openmicroscopy.org/teams/"
     },
     {
-        "@type": "Person",
-        "name": "June Matthew",
-        "affiliation": {
-          "@type": "Organization",
-          "name": "University of Dundee"
-        }
+      "@type": "Person",
+      "name": "June Matthew",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "University of Dundee"
+      },
+      "url": "https://www.openmicroscopy.org/teams/"
     },
     {
       "@type": "Person",
@@ -42,7 +45,8 @@
       "affiliation": {
         "@type": "Organization",
         "name": "University of Dundee"
-      }
+      },
+      "url": "https://www.openmicroscopy.org/teams/"
     }
   ],
   "subEvent": [
@@ -153,7 +157,8 @@
           "affiliation": {
             "@type": "Organization",
             "name": "University of Dundee"
-          }
+          },
+          "url": "https://www.openmicroscopy.org/teams/"
         }
       ],
       "performer": [
@@ -290,7 +295,8 @@
           "affiliation": {
             "@type": "Organization",
             "name": "University of Dundee"
-          }
+          },
+          "url": "https://www.openmicroscopy.org/teams/"
         }
       ],
       "performer": [
@@ -429,7 +435,8 @@
           "affiliation": {
             "@type": "Organization",
             "name": "University of Dundee"
-          }
+          },
+          "url": "https://www.openmicroscopy.org/teams/"
         }
       ],
       "performer": [

--- a/events/ome-community-meeting-2021/day1/index.html
+++ b/events/ome-community-meeting-2021/day1/index.html
@@ -1,7 +1,7 @@
 ---
 layout: ome-community-meeting-program-2021
 nav-day1: active
-title: Day 1
+title: OME 2021 Day 1
 subheader: TBD
 ---
 {% assign event=site.data.ome2021.subEvent[0] %}

--- a/events/ome-community-meeting-2021/day2/index.html
+++ b/events/ome-community-meeting-2021/day2/index.html
@@ -1,7 +1,7 @@
 ---
 layout: ome-community-meeting-program-2021
 nav-day2: active
-title: Day 2
+title: OME 2021 Day 2
 subheader: TBD
 ---
 

--- a/events/ome-community-meeting-2021/day4/index.html
+++ b/events/ome-community-meeting-2021/day4/index.html
@@ -1,7 +1,7 @@
 ---
 layout: ome-community-meeting-program-2021
 nav-day4: active
-title: Day 4
+title: OME 2021 Day 4
 subheader: TBD
 ---
 

--- a/events/ome-community-meeting-2021/index.html
+++ b/events/ome-community-meeting-2021/index.html
@@ -1,7 +1,7 @@
 ---
 layout: ome-community-meeting-program-2021
 nav-overview: active
-title: Overview
+title: OME 2021 Community Meeting
 schemadotorg: ome2021
 ---
 


### PR DESCRIPTION
Fixes a few warnings reported by the [Rich Results Tests](https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=jsonld&utm_source=livestream&user_agent=1&url=https%3A%2F%2Fwww.openmicroscopy.org%2Fevents%2Fome-community-meeting-2021%2F)

- Add `eventAttendanceMode/eventStatus` for each `Event`
- Add `organizer.url`
- Add `organizer` for each of the days 2-4
- Add event  registration as `offers`