### PR TITLE
Agenda sessions

### DIFF
--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -95,62 +95,95 @@
       "subEvent": [
         {
           "@type": "Event",
-          "name": "Introduction",
+          "name": "Session 1",
+          "description": "This session is aimed at our
+          community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-08T10:00+01:00",
-          "endDate": "2021-06-08T11:00+01:00",
+          "startDate": "2021-06-09T10:00+01:00",
+          "endDate": "2021-06-09T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Demos",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-08T11:00+01:00",
-          "endDate": "2021-06-08T14:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Keynote Lecture",
-          "description": "Title TBC",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-08T16:00+01:00",
-          "endDate": "2021-06-08T17:00+01:00",
-          "performer": [
+          },
+          "subEvent": [
             {
-              "@type": "Person",
-              "name": "Helen Berman",
-              "affiliation": {
-                "@type": "Organization",
-                "name": "RCSB PDB"
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-08T10:00+01:00",
+              "endDate": "2021-06-08T11:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "Demos",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-08T11:00+01:00",
+              "endDate": "2021-06-08T14:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
               }
             }
-          ],
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
+          ]
         },
         {
           "@type": "Event",
-          "name": "Demos",
+          "name": "Session 2",
+          "description": "This session is aimed at our
+          community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-08T17:00+01:00",
-          "endDate": "2021-06-08T20:00+01:00",
+          "startDate": "2021-06-09T10:00+01:00",
+          "endDate": "2021-06-09T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "subEvent": [
+            {
+              "@type": "Event",
+              "name": "Keynote Lecture",
+              "description": "Title TBC",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-08T16:00+01:00",
+              "endDate": "2021-06-08T17:00+01:00",
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Helen",
+                  "familyName": "Berman",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "RCSB PDB"
+                  }
+                }
+              ],
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "Demos",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-08T17:00+01:00",
+              "endDate": "2021-06-08T20:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            }
+          ]
         }
       ]
     },
@@ -318,8 +351,8 @@
           community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T10:00+01:00",
-          "endDate": "2021-06-09T13:00+01:00",
+          "startDate": "2021-06-09T16:00+01:00",
+          "endDate": "2021-06-09T19:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
@@ -473,75 +506,199 @@
       "subEvent": [
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Session 1",
+          "description": "This session is aimed at our
+          community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T10:00+01:00",
-          "endDate": "2021-06-10T11:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-10T11:00+01:00",
-          "endDate": "2021-06-10T12:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-10T12:00+01:00",
           "endDate": "2021-06-10T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "subEvent": [
+            {
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T10:00+01:00",
+              "endDate": "2021-06-10T10:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Sébastien",
+                  "familyName": "Besson",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T10:10+01:00",
+              "endDate": "2021-06-10T10:55+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "IDR Workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T11:00+01:00",
+              "endDate": "2021-06-10T12:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Jean-Marie",
+                  "familyName": "Burel",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                },
+                {
+                  "@type": "Person",
+                  "givenName": "Petr",
+                  "familyName": "Walczysko",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T12:30+01:00",
+              "endDate": "2021-06-10T13:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            }
+          ]
         },
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Session 2 (repeat of session 1)",
+          "description": "The second session is aimed at our
+          community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T16:00+01:00",
-          "endDate": "2021-06-10T17:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-10T17:00+01:00",
-          "endDate": "2021-06-10T18:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-10T18:00+01:00",
           "endDate": "2021-06-10T19:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "subEvent": [
+            {
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T16:00+01:00",
+              "endDate": "2021-06-10T16:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Sébastien",
+                  "familyName": "Besson",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T16:10+01:00",
+              "endDate": "2021-06-10T16:55+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "IDR Workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T17:00+01:00",
+              "endDate": "2021-06-10T18:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Jean-Marie",
+                  "familyName": "Burel",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                },
+                {
+                  "@type": "Person",
+                  "givenName": "Petr",
+                  "familyName": "Walczysko",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-10T18:30+01:00",
+              "endDate": "2021-06-10T19:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            }
+          ]
         }
       ]
     },
@@ -627,75 +784,179 @@
       "subEvent": [
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Session 1",
+          "description": "The first session is aimed at our community
+          attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T10:00+01:00",
-          "endDate": "2021-06-11T11:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-11T11:00+01:00",
-          "endDate": "2021-06-11T12:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-11T12:00+01:00",
           "endDate": "2021-06-11T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "subEvent": [
+            {
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T09:00+01:00",
+              "endDate": "2021-06-11T09:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Jean-Marie",
+                  "familyName": "Burel",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T10:00+01:00",
+              "endDate": "2021-06-11T11:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "OMERO trainers Workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T11:00+01:00",
+              "endDate": "2021-06-11T12:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Petr",
+                  "familyName": "Walczysko",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T12:30+01:00",
+              "endDate": "2021-06-11T13:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            }
+          ]
         },
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Session 2 (repeat of session 1)",
+          "description": "The first session is aimed at our community
+          attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T16:00+01:00",
-          "endDate": "2021-06-11T17:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-11T17:00+01:00",
-          "endDate": "2021-06-11T18:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-11T18:00+01:00",
           "endDate": "2021-06-11T19:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "subEvent": [
+            {
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T16:00+01:00",
+              "endDate": "2021-06-11T16:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Jean-Marie",
+                  "familyName": "Burel",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T16:10+01:00",
+              "endDate": "2021-06-11T16:55+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "OMERO trainers Workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T17:00+01:00",
+              "endDate": "2021-06-11T18:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Petr",
+                  "familyName": "Walczysko",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-11T18:30+01:00",
+              "endDate": "2021-06-11T19:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            }
+          ]
         }
       ]
     }

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -225,147 +225,179 @@
       "subEvent": [
         {
           "@type": "Event",
-          "name": "Introduction",
+          "name": "Session 1",
+          "description": "The first session is aimed at our community
+          attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T10:00+01:00",
-          "endDate": "2021-06-09T10:10+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          },
-          "performer": [
-            {
-              "@type": "Person",
-              "givenName": "Josh",
-              "familyName": "Moore",
-              "affiliation": {
-                "@type": "Organization",
-                "name": "University of Dundee"
-              },
-              "sameAs": "https://www.openmicroscopy.org/teams/"
-            }
-          ]
-        },
-        {
-          "@type": "Event",
-          "name": "Q&A session",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T10:10+01:00",
-          "endDate": "2021-06-09T10:55+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "OMERO.figure workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T11:00+01:00",
-          "endDate": "2021-06-09T12:20+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          },
-          "performer": [
-            {
-              "@type": "Person",
-              "givenName": "William",
-              "familyName": "Moore",
-              "affiliation": {
-                "@type": "Organization",
-                "name": "University of Dundee"
-              },
-              "sameAs": "https://www.openmicroscopy.org/teams/"
-            }
-          ]
-        },
-        {
-          "@type": "Event",
-          "name": "Break-out sessions",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T12:30+01:00",
           "endDate": "2021-06-09T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Introduction",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T16:00+01:00",
-          "endDate": "2021-06-09T16:10+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
           },
-          "performer": [
+          "subEvent": [
             {
-              "@type": "Person",
-              "givenName": "Josh",
-              "familyName": "Moore",
-              "affiliation": {
-                "@type": "Organization",
-                "name": "University of Dundee"
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T10:00+01:00",
+              "endDate": "2021-06-09T10:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
               },
-              "sameAs": "https://www.openmicroscopy.org/teams/"
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Josh",
+                  "familyName": "Moore",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T10:10+01:00",
+              "endDate": "2021-06-09T10:55+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "OMERO.figure workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T11:00+01:00",
+              "endDate": "2021-06-09T12:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "William",
+                  "familyName": "Moore",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T12:30+01:00",
+              "endDate": "2021-06-09T13:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
             }
           ]
         },
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Session 2 (repeat of Session 1)",
+          "description": "The second session is aimed at our
+          community attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T16:10+01:00",
-          "endDate": "2021-06-09T16:55+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
-        },
-        {
-          "@type": "Event",
-          "name": "Workshop",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T17:00+01:00",
-          "endDate": "2021-06-09T18:20+01:00",
+          "startDate": "2021-06-09T10:00+01:00",
+          "endDate": "2021-06-09T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
           },
-          "performer": [
+          "subEvent": [
             {
-              "@type": "Person",
-              "givenName": "William",
-              "familyName": "Moore",
-              "affiliation": {
-                "@type": "Organization",
-                "name": "University of Dundee"
+              "@type": "Event",
+              "name": "Introduction",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T16:00+01:00",
+              "endDate": "2021-06-09T16:10+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
               },
-              "sameAs": "https://www.openmicroscopy.org/teams/"
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "Josh",
+                  "familyName": "Moore",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Q&A session",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T16:10+01:00",
+              "endDate": "2021-06-09T16:55+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
+            },
+            {
+              "@type": "Event",
+              "name": "OMERO.figure workshop",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T17:00+01:00",
+              "endDate": "2021-06-09T18:20+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              },
+              "performer": [
+                {
+                  "@type": "Person",
+                  "givenName": "William",
+                  "familyName": "Moore",
+                  "affiliation": {
+                    "@type": "Organization",
+                    "name": "University of Dundee"
+                  },
+                  "sameAs": "https://www.openmicroscopy.org/teams/"
+                }
+              ]
+            },
+            {
+              "@type": "Event",
+              "name": "Break-out sessions",
+              "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+              "eventStatus": "https://schema.org/EventScheduled",
+              "startDate": "2021-06-09T18:30+01:00",
+              "endDate": "2021-06-09T19:00+01:00",
+              "location": {
+                "@type": "VirtualLocation",
+                "url": "TBD"
+              }
             }
           ]
-        },
-        {
-          "@type": "Event",
-          "name": "Break-out sessions",
-          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-          "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T18:30+01:00",
-          "endDate": "2021-06-09T19:00+01:00",
-          "location": {
-            "@type": "VirtualLocation",
-            "url": "TBD"
-          }
         }
       ]
     },

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -225,11 +225,35 @@
       "subEvent": [
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Introduction",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T10:00+01:00",
-          "endDate": "2021-06-09T11:00+01:00",
+          "endDate": "2021-06-09T10:10+01:00",
+          "location": {
+            "@type": "VirtualLocation",
+            "url": "TBD"
+          },
+          "performer": [
+            {
+              "@type": "Person",
+              "givenName": "Josh",
+              "familyName": "Moore",
+              "affiliation": {
+                "@type": "Organization",
+                "name": "University of Dundee"
+              },
+              "sameAs": "https://www.openmicroscopy.org/teams/"
+            }
+          ]
+        },
+        {
+          "@type": "Event",
+          "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
+          "startDate": "2021-06-09T10:10+01:00",
+          "endDate": "2021-06-09T10:55+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
@@ -237,22 +261,34 @@
         },
         {
           "@type": "Event",
-          "name": "Workshop",
+          "name": "OMERO.figure workshop",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T11:00+01:00",
-          "endDate": "2021-06-09T12:00+01:00",
+          "endDate": "2021-06-09T12:20+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "performer": [
+            {
+              "@type": "Person",
+              "givenName": "William",
+              "familyName": "Moore",
+              "affiliation": {
+                "@type": "Organization",
+                "name": "University of Dundee"
+              },
+              "sameAs": "https://www.openmicroscopy.org/teams/"
+            }
+          ]
         },
         {
           "@type": "Event",
-          "name": "Workshop",
+          "name": "Break-out sessions",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T12:00+01:00",
+          "startDate": "2021-06-09T12:30+01:00",
           "endDate": "2021-06-09T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
@@ -261,11 +297,35 @@
         },
         {
           "@type": "Event",
-          "name": "Q&A session",
+          "name": "Introduction",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T16:00+01:00",
-          "endDate": "2021-06-09T17:00+01:00",
+          "endDate": "2021-06-09T16:10+01:00",
+          "location": {
+            "@type": "VirtualLocation",
+            "url": "TBD"
+          },
+          "performer": [
+            {
+              "@type": "Person",
+              "givenName": "Josh",
+              "familyName": "Moore",
+              "affiliation": {
+                "@type": "Organization",
+                "name": "University of Dundee"
+              },
+              "sameAs": "https://www.openmicroscopy.org/teams/"
+            }
+          ]
+        },
+        {
+          "@type": "Event",
+          "name": "Q&A session",
+          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+          "eventStatus": "https://schema.org/EventScheduled",
+          "startDate": "2021-06-09T16:10+01:00",
+          "endDate": "2021-06-09T16:55+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
@@ -277,18 +337,30 @@
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T17:00+01:00",
-          "endDate": "2021-06-09T18:00+01:00",
+          "endDate": "2021-06-09T18:20+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
-          }
+          },
+          "performer": [
+            {
+              "@type": "Person",
+              "givenName": "William",
+              "familyName": "Moore",
+              "affiliation": {
+                "@type": "Organization",
+                "name": "University of Dundee"
+              },
+              "sameAs": "https://www.openmicroscopy.org/teams/"
+            }
+          ]
         },
         {
           "@type": "Event",
-          "name": "Workshop",
+          "name": "Break-out sessions",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T18:00+01:00",
+          "startDate": "2021-06-09T18:30+01:00",
           "endDate": "2021-06-09T19:00+01:00",
           "location": {
             "@type": "VirtualLocation",

--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -75,7 +75,7 @@
       "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
       "eventStatus": "https://schema.org/EventScheduled",
       "startDate": "2021-06-08T10:00+01:00",
-      "endDate": "2021-06-08T20:00+01:00",
+      "endDate": "2021-06-08T19:00+01:00",
       "location": {
         "@type": "VirtualLocation",
         "url": "TBD"
@@ -96,12 +96,12 @@
         {
           "@type": "Event",
           "name": "Session 1",
-          "description": "This session is aimed at our
-          community attending from Europe, Africa or America.",
+          "description": "This session is aimed at our community
+          attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T10:00+01:00",
-          "endDate": "2021-06-09T13:00+01:00",
+          "startDate": "2021-06-08T10:00+01:00",
+          "endDate": "2021-06-08T13:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
@@ -125,7 +125,7 @@
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
               "startDate": "2021-06-08T11:00+01:00",
-              "endDate": "2021-06-08T14:00+01:00",
+              "endDate": "2021-06-08T13:00+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -136,12 +136,12 @@
         {
           "@type": "Event",
           "name": "Session 2",
-          "description": "This session is aimed at our
-          community attending from Europe, Africa or America.",
+          "description": "This session is aimed at our community
+          attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
-          "startDate": "2021-06-09T10:00+01:00",
-          "endDate": "2021-06-09T13:00+01:00",
+          "startDate": "2021-06-08T16:00+01:00",
+          "endDate": "2021-06-08T19:00+01:00",
           "location": {
             "@type": "VirtualLocation",
             "url": "TBD"
@@ -177,7 +177,7 @@
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
               "startDate": "2021-06-08T17:00+01:00",
-              "endDate": "2021-06-08T20:00+01:00",
+              "endDate": "2021-06-08T19:00+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -259,7 +259,7 @@
         {
           "@type": "Event",
           "name": "Session 1",
-          "description": "The first session is aimed at our community
+          "description": "This session is aimed at our community
           attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
@@ -347,8 +347,8 @@
         {
           "@type": "Event",
           "name": "Session 2 (repeat of Session 1)",
-          "description": "The second session is aimed at our
-          community attending from Europe, Africa or America.",
+          "description": "This session is aimed at our community
+          attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-09T16:00+01:00",
@@ -507,8 +507,8 @@
         {
           "@type": "Event",
           "name": "Session 1",
-          "description": "This session is aimed at our
-          community attending from Europe, Africa or America.",
+          "description": "This session is aimed at our community
+          attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T10:00+01:00",
@@ -605,8 +605,8 @@
         {
           "@type": "Event",
           "name": "Session 2 (repeat of session 1)",
-          "description": "The second session is aimed at our
-          community attending from Europe, Africa or America.",
+          "description": "This session is aimed at our community
+          attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-10T16:00+01:00",
@@ -785,7 +785,7 @@
         {
           "@type": "Event",
           "name": "Session 1",
-          "description": "The first session is aimed at our community
+          "description": "This session is aimed at our community
           attending from Oceania, Asia, Europe or Africa.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
@@ -801,8 +801,8 @@
               "name": "Introduction",
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
-              "startDate": "2021-06-11T09:00+01:00",
-              "endDate": "2021-06-11T09:10+01:00",
+              "startDate": "2021-06-11T10:00+01:00",
+              "endDate": "2021-06-11T10:10+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -825,8 +825,8 @@
               "name": "Q&A session",
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
-              "startDate": "2021-06-11T10:00+01:00",
-              "endDate": "2021-06-11T11:00+01:00",
+              "startDate": "2021-06-11T10:10+01:00",
+              "endDate": "2021-06-11T10:55+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -873,8 +873,8 @@
         {
           "@type": "Event",
           "name": "Session 2 (repeat of session 1)",
-          "description": "The first session is aimed at our community
-          attending from Oceania, Asia, Europe or Africa.",
+          "description": "This session is aimed at our community
+          attending from Europe, Africa or America.",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "eventStatus": "https://schema.org/EventScheduled",
           "startDate": "2021-06-11T16:00+01:00",

--- a/_includes/ome2021_program_agenda.html
+++ b/_includes/ome2021_program_agenda.html
@@ -46,8 +46,8 @@
   <div class="medium-8 columns">
     <a name="{{ subevent.name }}"></a><h5>{{ subevent.name }}</h5>
     <p>
-    {% if subevent.description %}{{ subevent.description }}{% endif %}
-    {% for performer in subevent.performer %}{{ performer.givenName }} {{ performer.familyName }}, <span class="ome-green italic">{{ performer.affiliation.name }}</span>{% endfor %}
+    {% if subevent.description %}{{ subevent.description }}<br/>{% endif %}
+    {% for performer in subevent.performer %}{{ performer.givenName }} {{ performer.familyName }}, <span class="ome-green italic">{{ performer.affiliation.name }}</span><br/>{% endfor %}
     </p>
   </div>
   {% endfor %}

--- a/_includes/ome2021_program_agenda.html
+++ b/_includes/ome2021_program_agenda.html
@@ -36,6 +36,7 @@
   <div class="medium-8 columns">
     <a name="{{ subevent.name }}"></a><h5>{{ subevent.name }}</h5>
     {% if subevent.description %}<p>{{ subevent.description }}</p>{% endif %}
+    {% for performer in subevent.performer %}<p>{{ performer.givenName }} {{ performer.familyName }}, <span class="ome-green italic">{{ performer.affiliation.name }}</span></p>{% endfor %}
   </div>
   {% endfor %}
 </div>

--- a/_includes/ome2021_program_agenda.html
+++ b/_includes/ome2021_program_agenda.html
@@ -10,15 +10,11 @@
     <h5>Please Note</h5>
     <p>
         This schedule is subject to change and will be updated periodically.<br/>
-        The schedule will include pre-recorded videos organised by topic followed by group discussions.<br/>
-        Please find time to watch the videos <strong>before</strong> the corresponding discussion
-        on each topic.<br/>
-        All times are in UK - British Summer Time (GMT+1).
+        The schedule will include pre-recorded videos organised by topic followed by group discussions.
     </p>
 </div>
 
-<hr class="invisible">
-<h5 class="row column text-center">Speakers</h5>
+<h4 class="row column text-center">Speakers</h4>
 {% for speaker in event.performer  %}
 <div class="row small-up-1 medium-up-2 text-center consortium-list">
 <a target="_blank" href="{{ speaker.sameAs }}">
@@ -29,18 +25,34 @@
 {% endfor %}
 </p>
 
-<h5 class="row column text-center">Schedule</h5>
+<div class="row column text-center">
+<h4>Schedule</h4>
+<p>
+    The content will repeated over two sessions to accomodate our
+    community across timezones.<br/>
+    Please find time to watch the videos <strong>before</strong> the corresponding discussion
+    on each topic.<br/>
+    All times are in UK - British Summer Time (GMT+1).
+</p>
+</div> 
+{% for session in event.subEvent %}
+<div class="row column text-center">
+<h5>{{ session.name }}</h5>
+<p>{{ session.description }}</p>
+</div> 
 <div class="row align-right">
-  {% for subevent in event.subEvent %}
+  {% for subevent in session.subEvent %}
   <div class="medium-2 medium-offset-2 columns bold"><i class="fa fa-clock-o"></i> {{ subevent.startDate | date: "%H:%M" }} - {{ subevent.endDate | date: "%H:%M" }}</div>
   <div class="medium-8 columns">
     <a name="{{ subevent.name }}"></a><h5>{{ subevent.name }}</h5>
-    {% if subevent.description %}<p>{{ subevent.description }}</p>{% endif %}
-    {% for performer in subevent.performer %}<p>{{ performer.givenName }} {{ performer.familyName }}, <span class="ome-green italic">{{ performer.affiliation.name }}</span></p>{% endfor %}
+    <p>
+    {% if subevent.description %}{{ subevent.description }}{% endif %}
+    {% for performer in subevent.performer %}{{ performer.givenName }} {{ performer.familyName }}, <span class="ome-green italic">{{ performer.affiliation.name }}</span>{% endfor %}
+    </p>
   </div>
   {% endfor %}
 </div>
-
+{% endfor %}
 
 {% if event.workFeatured %}
 


### PR DESCRIPTION
Discussed as part of the first workshop rehearsal, this PR improves the in-progress agenda for the [OME 2021 community meeting](https://www.openmicroscopy.org/events/ome-community-meeting-2021/)

- group individual event under a new intermediate event for each of the two daily sessions
- update the agenda template to reflect this session subheading
- update day 1 - 3 schedule to reflect the current agenda (intro, Q&A, workshop, break-out) per session
- update Introduction and Workshop event title and performers