### PR TITLE
Change break-out sessions into Concluding remarks for Day 4

### DIFF
--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -860,7 +860,7 @@
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
               "startDate": "2021-06-11T11:00+01:00",
-              "endDate": "2021-06-11T12:20+01:00",
+              "endDate": "2021-06-11T12:30+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -880,10 +880,10 @@
             },
             {
               "@type": "Event",
-              "name": "Break-out sessions",
+              "name": "Concluding remarks",
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
-              "startDate": "2021-06-11T12:30+01:00",
+              "startDate": "2021-06-11T12:40+01:00",
               "endDate": "2021-06-11T13:00+01:00",
               "location": {
                 "@type": "VirtualLocation",
@@ -948,7 +948,7 @@
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
               "startDate": "2021-06-11T17:00+01:00",
-              "endDate": "2021-06-11T18:20+01:00",
+              "endDate": "2021-06-11T18:30+01:00",
               "location": {
                 "@type": "VirtualLocation",
                 "url": "TBD"
@@ -968,10 +968,10 @@
             },
             {
               "@type": "Event",
-              "name": "Break-out sessions",
+              "name": "Concluding remarks",
               "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
               "eventStatus": "https://schema.org/EventScheduled",
-              "startDate": "2021-06-11T18:30+01:00",
+              "startDate": "2021-06-11T18:40+01:00",
               "endDate": "2021-06-11T19:00+01:00",
               "location": {
                 "@type": "VirtualLocation",


### PR DESCRIPTION
As discussed earlier today, the last 20min of each session on Day 4 should be used for closing the meeting.