### PR TITLE
Fix link to explore

### DIFF
--- a/omero/institution/getting-started.html
+++ b/omero/institution/getting-started.html
@@ -34,7 +34,7 @@ meta_description: To help you get started installing OMERO for your institution,
                 </ul>
                 <h5>Read and watch about OMERO or try it to get a better idea.</h5>
                 <ul class="dev-ops-links">
-                    <li><a href="{{ site.baseurl }}//explore/" target="_blank">Give OMERO a quick try</a></li>
+                    <li><a href="{{ site.baseurl }}/explore/" target="_blank">Give OMERO a quick try</a></li>
                     <li><a href="{{ site.baseurl }}/omero/institution/" target="_blank">Further read on advantages of OMERO for your institution</a></li>
                     <li><a href="{{ site.baseurl }}/omero/features/index.html" target="_blank">List of OMERO features</a></li>
                     <li><a href="https://omero-guides.readthedocs.io/en/latest/index.html" target="_blank">OMERO guides</a></li>


### PR DESCRIPTION
Found out during a demo on OME2021. The link "Give OMERO a quick try" on https://www.openmicroscopy.org/omero/institution/ is broken, which is not detectable either on local build nor on snoopy (only on the production site).


