### PR TITLE
Temporarily use custom User-Agent for htmlproofer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -u
 docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
 # Report 4xx status codes except 429 errors (Too Many Requests)
 # typically sent by GitHub while linkchecking the downloads
-docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/' --url-ignore "/twitter.com/"
+docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --http-status-ignore "429" --file_ignore '/minutes/' --url-ignore "/twitter.com/" --typhoeus-config='{"headers" : {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/91.0.4472.164 Safari/537.36"}}'
 
 # Test file existence
 echo "Checking Schemas existence"


### PR DESCRIPTION
The GitHub actions have been broken for the last 10 days due to an impossibility to validate a Science DOI. This seems to be related to the upstream website blocking user agents - see https://github.com/gjtorikian/html-proofer/issues/648 for the related conversation.

This PR passes a custom Mozilla agent to workaround the problem. The Science website has been separately contacted (https://www.sciencemag.org/about/contact-us) to ask about adding the htmlproofer to the allowed list. Hopefully this means this workaround can be reverted in the near future.
