### PR TITLE
point to orcid

### DIFF
--- a/_data/ome2021.json
+++ b/_data/ome2021.json
@@ -1852,7 +1852,7 @@ microscopy metadata based on community-driven specifications",
             "@type": "Organization",
             "name": "University of Dundee"
           },
-          "sameAs": "https://www.dundee.ac.uk/people/paul-felts"
+          "sameAs": "https://orcid.org/0000-0003-0762-4580"
         },
         {
           "@type": "Person",


### PR DESCRIPTION
Use orcid instead of link to dundee.
Paul has now retired and the page is gone