### PR TITLE
Add citation for 2021 OME-NGFF paper

### DIFF
--- a/citing-ome/index.html
+++ b/citing-ome/index.html
@@ -43,6 +43,21 @@ meta_description: Learn how to properly cite OME work in your own publications.
         <hr class="whitespace">
         <div class="row">
             <div class="small-12 medium-4 columns">
+                <h3>OME-NGFF</h3>
+            </div>
+            <div class="small-12 medium-8 columns">
+                <p class="citation">Josh Moore, Chris Allan, Sébastien Besson, Jean-Marie Burel, Erin Diel, David Gault, Kevin Kozlowski, Dominik Lindner, Melissa Linkert, Trevor Manz, Will Moore, Constantin Pape, Christian Tischer & Jason R. Swedlow (2021). OME-NGFF: a next-generation file format for expanding bioimaging data-access strategies. Nature methods (2021). Published: 29 November 2021</p>
+                <p>DOI: <a href="https://doi.org/10.1038/s41592-021-01326-w" target="_blank">10.1038/s41592-021-01326-w</a>
+                PMID: <a href="https://www.ncbi.nlm.nih.gov/pubmed/34845388/" target="_blank">34845388</a>
+                </p>
+            </div>
+        </div>
+        <!-- end citation-->
+
+        <!-- begin citation-->
+        <hr class="whitespace">
+        <div class="row">
+            <div class="small-12 medium-4 columns">
                 <h3>Bio-Formats</h3>
             </div>
             <div class="small-12 medium-8 columns">


### PR DESCRIPTION
Now that the paper is out, add a citation for https://doi.org/10.1038/s41592-021-01326-w using a new heading

NB: I considered going the road (rabbit hole?) of converting the content of this page into data files using https://schema.org/ScholarlyArticle. Unsure whether anyone has strong views on the value of doing that.