### PR TITLE
Add GBI courses 2022

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -9,6 +9,12 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
         <!-- begin Events -->
         <hr class="whitespace">
         <div id="community-posts" class="row">
+            <hr class="medium-8">
+            <div class="small-12 medium-8 medium-offset-2 columns">
+                <h6><i class="fa fa-calendar"></i> January 25 and 26, 2022</h6>
+                <h2><a href="workshops-gbi-january-2022.html">OMERO and IDR Workshops, GBI</a></h2>
+                <p class="card-caption">2 workshops on OMERO and IDR held remotely.</p>
+            </div>
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> November 18 2021</h6>
                 <h2><a href="omero-workshop-eastbio-dundee-november-2021.html">OMERO Workshop, EastBio, held remotely</a></h2>

--- a/events/index.html
+++ b/events/index.html
@@ -9,12 +9,12 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
         <!-- begin Events -->
         <hr class="whitespace">
         <div id="community-posts" class="row">
-            <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> January 25 and 26, 2022</h6>
                 <h2><a href="workshops-gbi-january-2022.html">OMERO and IDR Workshops, GBI</a></h2>
                 <p class="card-caption">2 workshops on OMERO and IDR held remotely.</p>
             </div>
+            <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> November 18 2021</h6>
                 <h2><a href="omero-workshop-eastbio-dundee-november-2021.html">OMERO Workshop, EastBio, held remotely</a></h2>

--- a/events/workshops-gbi-january-2022.html
+++ b/events/workshops-gbi-january-2022.html
@@ -39,7 +39,7 @@ main-blurb: 2 online workshops (ca 3.5 hours per day in two days) given by the O
         <div class="row">
             <div class="column">
                 <h2 class="event-day">Duration: 3.5-hours (OMERO workshop) and 3 hours (IDR workshop) </h2>
-                <p class="event-day-description">The OMERO workshop will focus on several key areas including data management of image data using OMERO open source data management solution. In the second workshop on the following day, the Image Data Resource (IDR) will be introduced and simple searches as well as more complex queries using API in the IDR will be shown. For more details and to apply for the workshop(s), please visit <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">OMERO workshop</a> and/or  <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">IDR workshop</a> as appropriate.
+                <p class="event-day-description">The OMERO workshop will focus on several key areas including data management of image data using OMERO open source data management solution. In the second workshop on the following day, the Image Data Resource (IDR) will be introduced and simple searches as well as more complex queries using the IDR API will be shown. For more details and to apply for the workshop(s), please visit <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">OMERO workshop</a> and/or  <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">IDR workshop</a> as appropriate.
                 </p>
             </div>
         </div>

--- a/events/workshops-gbi-january-2022.html
+++ b/events/workshops-gbi-january-2022.html
@@ -1,0 +1,45 @@
+---
+layout: news-events
+filename: events
+title: January 2022 OME users workshops
+main-blurb: 2 online workshops (ca 3.5 hours per day in two days) given by the OME Team on OMERO and IDR organized by Global BioImaging.
+---
+     <hr class="whitespace">
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Organisers: <a href="https://globalbioimaging.org/" target="_blank">Global BioImaging</a></h2>
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Location: held remotely
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Workshop 1.: <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">OMERO: Management, sharing, publication and analysis of image data</a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Date: 25 January 2022</h2>
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Workshop 2.: <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">IDR: A resource for publication, reference and re-analysis of image data</a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Date: 26 January 2022</h2>
+            </div>
+        </div>
+        <hr class="whitespace">
+        <div class="row">
+            <div class="column">
+                <h2 class="event-day">Duration: 3.5-hours (OMERO workshop) and 3 hours (IDR workshop) </h2>
+                <p class="event-day-description">The OMERO workshop will focus on several key areas including data management of image data using OMERO open source data management solution. In the second workshop on the following day, the Image Data Resource (IDR) will be introduced and simple searches as well as more complex queries using API in the IDR will be shown. For more details and to apply for the workshop(s), please visit <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">OMERO workshop</a> and/or  <a href="https://globalbioimaging.org/international-training-courses/omero-workshop-2022" target="_blank">IDR workshop</a> as appropriate.
+                </p>
+            </div>
+        </div>


### PR DESCRIPTION
As discussed with @jburel - we have now the 2 courses (OMERO and IDR) scheduled and [advertised by GBI](https://globalbioimaging.org/international-training-courses).
Happy to add the NGFF course as per info by @joshmoore , either in this or a follow-up PR.


Build on https://snoopycrimecop.github.io/www.openmicroscopy.org/events/