### PR TITLE
Review usage of NGFF vs OME-NGFF

### DIFF
--- a/_posts/2021-12-16-ngff.md
+++ b/_posts/2021-12-16-ngff.md
@@ -4,7 +4,7 @@ title: OME-NGFF 2021 updates
 tags: file-formats community
 categories: blog
 redirect_from:
-  - /2021/12/16/ngff.html
+  - /2021/12/16/ome-ngff.html
 
 ---
 

--- a/_posts/2021-12-16-ome-ngff.md
+++ b/_posts/2021-12-16-ome-ngff.md
@@ -3,6 +3,9 @@ layout: post
 title: OME-NGFF 2021 updates
 tags: file-formats community
 categories: blog
+redirect_from:
+  - /2021/12/16/ngff.html
+
 ---
 
 In 2020, we published two blog posts reporting on the development of
@@ -11,13 +14,13 @@ shared public examples of
 [multiscale images and label images]({{ site.baseurl }}{% post_url 2020-11-04-zarr-data %}) in November 2020
 and [high-content screening (HCS) datasets]({{ site.baseurl }}{% post_url 2020-12-01-zarr-hcs %}) in December 2020.
 
-Here we report progress made on NGFFs over the course of 2021 with contributions from [OME](https://www.openmicroscopy.org/),
+Here we report progress made on OME-NGFF over the course of 2021 with contributions from [OME](https://www.openmicroscopy.org/),
 [Glencoe Software](https://www.glencoesoftware.com/),
 [EMBL](https://www.embl.org/groups/kreshuk/)
 and [Harvard Medical School](http://gehlenborglab.org).
 
 
-## NGFF paper
+## OME-NGFF paper
 
 The principle of next-generation file formats as a solution for bioimaging
 data storage and access was recently published as a
@@ -45,7 +48,7 @@ section of the paper for more details.
 
 ## Dimension separator
 
-Preliminary results for the latency benchmark of the NGFF paper revealed
+Preliminary results for the latency benchmark of the OME-NGFF paper revealed
 performance issues when accessing Zarr chunks remotely for some modalities.
 Our tests showed that the source of these issues was related to the separator
 used between chunks in the Zarr format. The version
@@ -59,19 +62,19 @@ like Zarr will be moving to `/` as the default.
 ## 2D-5D axes
 
 Until version 0.2, the axes of multiscales images were implicitly assumed to
-be XYZCT. The [0.3](https://ngff.openmicroscopy.org/0.3/) version of the NGFF
-specification loosened this requirement by introducing a mandatory axes
-attribute in the `multiscales` specification. This extends  dimensionality
+be XYZCT. The [0.3](https://ngff.openmicroscopy.org/0.3/) version of the
+OME-NGFF specification loosened this requirement by introducing a mandatory
+axes attribute in the `multiscales` specification. This extends  dimensionality
 between 2D and 5D. For instance, it is possible to store a time-lapse 2D image
 using XYT or a three-dimensional volume as XYZ.
 
-## NGFF sample data
+## OME-NGFF sample data
 
 The two features discussed above (dimension separator and 2D-5D axes) are
 published in the
-[latest NGFF specification](https://ngff.openmicroscopy.org/latest/),
-currently at version 0.3. We generated a comprehensive set of 0.3 NGFF samples
-to cover all the current set of specifications:
+[latest OME-NGFF specification](https://ngff.openmicroscopy.org/latest/),
+currently at version 0.3. We generated a comprehensive set of 0.3 OME-NGFF
+samples to cover all the current set of specifications:
 
 <div class="row">
     <div class="small-12 small-centered medium-12 medium-centered columns">


### PR DESCRIPTION
Raised post-standup today, this aligns with the semantics used in https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8648559/ where NGFF is used to characterize the cloud-optimized formats like Zarr and typically balanced versus TIFF or HDF5 while OME-NGFF is used to talk about the format and the set of specifications built by OME and partners allowing to use NGFFs for storing, acessing and exchanging bioimaging data.

This implicitly proposes to rename the blog post URL to https://www.openmicroscopy.org/2021/12/16/ome-ngff.html (with a redirection from the former URL). For build reasons, the new URL will need to exist live to pass the linkchecker so 
541e386 first introduces a redirect from `ome-ngff.html` to `ngff.html`. Once deployed, a second change can swap the pages so that `ngff.html` redirects to `ome-ngff.html `

Staged at https://snoopycrimecop.github.io/www.openmicroscopy.org/2021/12/16/ngff.html for review