### PR TITLE
Button to copy s3 urls to clipboard

### DIFF
--- a/_posts/2020-11-04-zarr-data.md
+++ b/_posts/2020-11-04-zarr-data.md
@@ -28,6 +28,11 @@ will also provide links to sample HCS data in this format.
 <iframe style="width: 100%; height: 500px" name="vizarr" src="https://hms-dbmi.github.io/vizarr/v0.1/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr">
 </iframe>
 
+<style>
+    button.hollow {
+        margin: 0
+    }
+</style>
 <div class="row">
     <div class="small-12 small-centered medium-12 medium-centered columns">
         <div class="row horizontal">
@@ -65,9 +70,9 @@ will also provide links to sample HCS data in this format.
                             </a>
                         </td>
                         <td>
-                            <a title="S3 endpoint. Not for viewing!" href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/{{ row.Image }}.zarr">
+                            <button class="hollow button" title="S3 endpoint. Copy to clipboard" onclick="copyTextToClipboard('https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/{{ row.Image }}.zarr')">
                                 copy
-                            </a>
+                            </button>
                             {% if row.Image == '6001247' %}
                                 <br>(with <a href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/{{ row.Image }}.zarr/labels/">labels</a>)
                             {% endif %}

--- a/_posts/2020-12-01-zarr-hcs.md
+++ b/_posts/2020-12-01-zarr-hcs.md
@@ -31,6 +31,11 @@ Below is an example of a visual representation of an OME-Zarr plate using the [v
 The table below list all plates converted into version 0.1 of the OME-Zarr spec. This list is also available in
 [JSON format](https://raw.githubusercontent.com/ome/blog/master/_data/zarr_data_2020-12-01.json).
 
+<style>
+    button.hollow {
+        margin: 0
+    }
+</style>
 <div class="row">
     <div class="small-12 small-centered medium-12 medium-centered columns">
         <div class="row horizontal">
@@ -64,9 +69,9 @@ The table below list all plates converted into version 0.1 of the OME-Zarr spec.
                             </a>
                         </td>
                         <td>
-                            <a title="S3 endpoint. Not for viewing!" href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/{{ row.id }}.zarr">
+                            <button class="hollow button" title="S3 endpoint. Copy to clipboard" onclick="copyTextToClipboard('https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/{{ row.id }}.zarr')">
                                 copy
-                            </a>
+                            </button>
                         </td>
                     </tr>
                 {% endfor %}

--- a/_posts/2021-12-16-ome-ngff.md
+++ b/_posts/2021-12-16-ome-ngff.md
@@ -76,6 +76,11 @@ published in the
 currently at version 0.3. We generated a comprehensive set of 0.3 OME-NGFF
 samples to cover all the current set of specifications:
 
+<style>
+    button.hollow {
+        margin: 0
+    }
+</style>
 <div class="row">
     <div class="small-12 small-centered medium-12 medium-centered columns">
         <div class="row horizontal">
@@ -109,9 +114,9 @@ samples to cover all the current set of specifications:
                             </a>
                         </td>
                         <td>
-                            <a title="S3 endpoint. Not for viewing!" href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/{{ row.study }}{{ row.experiment }}/{{ row.id }}.zarr">
+                            <button class="hollow button" title="S3 endpoint. Copy to clipboard" onclick="copyTextToClipboard('https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/{{ row.study }}{{ row.experiment }}/{{ row.id }}.zarr')">
                                 copy
-                            </a>
+                            </button>
                         </td>
                     </tr>
                 {% endfor %}
@@ -134,9 +139,9 @@ samples to cover all the current set of specifications:
                             </a>
                         </td>
                         <td>
-                            <a title="S3 endpoint. Not for viewing!" href="https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/{{ row.study }}{{ row.screen }}/{{ row.id }}.zarr">
+                            <button class="hollow button" title="S3 endpoint. Copy to clipboard" onclick="copyTextToClipboard('https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/{{ row.study }}{{ row.screen }}/{{ row.id }}.zarr')">
                                 copy
-                            </a>
+                            </button>
                         </td>
                     </tr>
                 {% endfor %}

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,42 @@
 $(document).foundation()
 
-$(function(){
-	// We don't want main menu top links to be 'active' as links
-	// We can't replace the <a> because foundation uses them for collapsible menu on mobile
-	// and we can't set href="#" since the travis build fails.
-	$("#main-menu .has-submenu>a").click(event => event.preventDefault());
+$(function () {
+    // We don't want main menu top links to be 'active' as links
+    // We can't replace the <a> because foundation uses them for collapsible menu on mobile
+    // and we can't set href="#" since the travis build fails.
+    $("#main-menu .has-submenu>a").click(event => event.preventDefault());
 });
+
+
+function copyTextToClipboard(text) {
+    var textArea = document.createElement("textarea");
+    // Place in the top-left corner of screen regardless of scroll position.
+    textArea.style.position = 'fixed';
+
+    textArea.value = text;
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    var successful;
+    try {
+        successful = document.execCommand('copy');
+    } catch (err) {
+        console.log('Oops, unable to copy');
+    }
+    document.body.removeChild(textArea);
+
+    if (successful) {
+        // show user that copying happened - update text on element (e.g. button)
+        let target = event.target;
+        let html = target.innerHTML;
+        target.innerHTML = "Copied!"
+        setTimeout(() => {
+            // reset after 1 second
+            target.innerHTML = html
+        }, 1000)
+    } else {
+        console.log("Copying failed")
+    }
+}


### PR DESCRIPTION
See https://forum.image.sc/t/ome-zarr-conversion-tool/62234/10?u=will-moore

As requested, the NGFF blog posts now have a (Copy) button which copies the S3 endpoint to clipboard.
![Screenshot 2022-01-25 at 11 39 09](https://user-images.githubusercontent.com/900055/150970778-8625995e-339d-4749-aaaa-5e43958f24bc.png)



The text changes from "Copy" to "Copied!" for a second to indicate that it worked.

To test, click "Copy" button from each of the 3 pages and paste somewhere to check it.