### PR TITLE
Add announcement post for OMERO 5.6.5

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,9 +38,9 @@ bf:
  version: 6.10.0
 
 omero:
- version: 5.6.4
+ version: 5.6.5
  majorversion: 5.6
- build: b232
+ build: b233
  insight:
   version: 5.7.1
  matlab:

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -11,7 +11,7 @@ Today we are releasing OMERO.server 5.6.5 which includes:
 
 The OMEZarrReader inclusion allows the server to import imaging data written according to the 
 [OME-NGFF](https://ngff.openmicroscopy.org/) specification. The reader supports OME-NGFF datasets
-for all published versions of the specification, currently up to 0.4 and reads OME-XML
+for all published versions of the specification (up to and including 0.4) and reads OME-XML
 metadata stored using the layout written by Glencoe Software's
 [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility and currently under
 review for inclusion in the OME-NGFF specification - see [here](https://github.com/ome/ngff/pull/112).

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: Release of OMERO.server 5.6.5
+---
+
+Today we are releasing OMERO.server 5.6.5 which includes:
+
+- a new server configuration allowing to control the pyramidal requirement for floating-point images
+- an upgrade of Bio-Formats to version 6.10.0, see [release announcement]({{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html).
+- the inclusion of the OMEZarrReader version 0.3.0 for reading OME-NGFF data
+
+Note the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
+
+The loading of OME-NGFF data (version 0.1 to 0.4) is currently only available using the command-line
+interface - see the [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html) page
+for more details.
+
+Finally, the OMERO.server technical documentation has  been migrated to Read the Docs and
+the documentation for the stable version is available from https://omero.readthedocs.io/en/stable/.
+
+### Installing the Software:
+
+For full details of the changes with the OMERO 5.6 series see the
+[OMERO 5.6.0]({{ site.baseurl }}/2020/01/15/omero-5-6-0.html) release
+announcement. Full documentation for this release is available
+under <https://omero.readthedocs.io/en/stable/>.
+
+This release has been tested with
+[OMERO.py 5.11.2](https://pypi.org/project/omero-py/5.11.2/) and
+[OMERO.web 5.14.1](https://pypi.org/project/omero-web/5.14.1/) so we
+recommend that you upgrade OMERO.py and OMERO.web on your deployments.
+
+Official Docker images are available as usual on Docker Hub with either
+the latest or the 5.6 tag:
+
+* <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
+* <https://hub.docker.com/r/openmicroscopy/omero-server>
+
+You are invited to discuss this announcement on
+[the image.sc forum](https://forum.image.sc/tags/c/data-management/omero).
+
+All the best with your upgrades,
+
+The OME Team

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -5,15 +5,21 @@ title: Release of OMERO.server 5.6.5
 
 Today we are releasing OMERO.server 5.6.5 which includes:
 
-- a new server configuration allowing to control the pyramidal requirement for floating-point images
-- an upgrade of Bio-Formats to version 6.10.0, see [release announcement]({{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html).
-- the inclusion of the OMEZarrReader version 0.3.0 for reading OME-NGFF data
+-   a new server configuration allowing to control the pyramidal requirement for floating-point images
+-   an upgrade of Bio-Formats to the last released version 6.10.0, see the [release announcement]({{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html).
+-   the [OMEZarrReader](https://github.com/ome/ZarrReader/) version 0.3.0
+
+The OMEZarrReader inclusion allows the server to import imaging data written according to the 
+[OME-NGFF](https://ngff.openmicroscopy.org/) specification. The reader supports OME-NGFF datasets
+for all published versions of the specification, currently up to 0.4 and reads OME-XML
+metadata stored using to the layout written by Glencoe's
+[bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility and currently under
+review for inclusion in the OME-NGFF specification - see [here](https://github.com/ome/ngff/pull/112).
+OME-NGFF import is currently only available using the command-line interface, see the
+[limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
+for more details.
 
 Note the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
-
-The loading of OME-NGFF data (version 0.1 to 0.4) is currently only available using the command-line
-interface - see the [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
-for more details.
 
 Finally, the OMERO.server technical documentation has  been migrated to Read the Docs and
 the documentation for the stable version is available from <https://omero.readthedocs.io/en/stable/>.
@@ -23,7 +29,7 @@ the documentation for the stable version is available from <https://omero.readth
 For full details of the changes included in the OMERO 5.6 series see the
 [OMERO 5.6.0]({{ site.baseurl }}/2020/01/15/omero-5-6-0.html) release
 announcement. Full documentation for this release is available
-under <https://omero.readthedocs.io/en/stable/>.
+under <https://omero.readthedocs.io/en/v5.6.5/>.
 
 This release has been tested with
 [OMERO.py 5.11.2](https://pypi.org/project/omero-py/5.11.2/) and

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -28,7 +28,7 @@ under <https://omero.readthedocs.io/en/stable/>.
 This release has been tested with
 [OMERO.py 5.11.2](https://pypi.org/project/omero-py/5.11.2/) and
 [OMERO.web 5.14.1](https://pypi.org/project/omero-web/5.14.1/). We
-recommend that you upgrade OMERO.py and OMERO.web on your deployments.
+recommend that you upgrade OMERO.py and OMERO.web accordingly on your deployments.
 
 Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.6 tag:

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -27,7 +27,7 @@ under <https://omero.readthedocs.io/en/stable/>.
 
 This release has been tested with
 [OMERO.py 5.11.2](https://pypi.org/project/omero-py/5.11.2/) and
-[OMERO.web 5.14.1](https://pypi.org/project/omero-web/5.14.1/) so we
+[OMERO.web 5.14.1](https://pypi.org/project/omero-web/5.14.1/). We
 recommend that you upgrade OMERO.py and OMERO.web on your deployments.
 
 Official Docker images are available as usual on Docker Hub with either

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -16,7 +16,7 @@ interface - see the [limitations](https://omero.readthedocs.io/en/stable/sysadmi
 for more details.
 
 Finally, the OMERO.server technical documentation has  been migrated to Read the Docs and
-the documentation for the stable version is available from https://omero.readthedocs.io/en/stable/.
+the documentation for the stable version is available from <https://omero.readthedocs.io/en/stable/>.
 
 ### Installing the Software:
 

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -12,7 +12,7 @@ Today we are releasing OMERO.server 5.6.5 which includes:
 Note the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
 
 The loading of OME-NGFF data (version 0.1 to 0.4) is currently only available using the command-line
-interface - see the [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html) page
+interface - see the [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
 for more details.
 
 Finally, the OMERO.server technical documentation has  been migrated to Read the Docs and

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -12,7 +12,7 @@ Today we are releasing OMERO.server 5.6.5 which includes:
 The OMEZarrReader inclusion allows the server to import imaging data written according to the 
 [OME-NGFF](https://ngff.openmicroscopy.org/) specification. The reader supports OME-NGFF datasets
 for all published versions of the specification, currently up to 0.4 and reads OME-XML
-metadata stored using to the layout written by Glencoe's
+metadata stored using the layout written by Glencoe Software's
 [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility and currently under
 review for inclusion in the OME-NGFF specification - see [here](https://github.com/ome/ngff/pull/112).
 OME-NGFF import is currently only available using the command-line interface, see the

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -21,7 +21,7 @@ for more details.
 
 Note the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
 
-Finally, the OMERO.server technical documentation has  been migrated to Read the Docs and
+Finally, the OMERO.server technical documentation has been migrated to Read the Docs and
 the documentation for the stable version is available from <https://omero.readthedocs.io/en/stable/>.
 
 ### Installing the Software:

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -14,7 +14,7 @@ The OMEZarrReader inclusion allows the server to import imaging data written acc
 for all published versions of the specification (up to and including 0.4) and reads OME-XML
 metadata stored using the layout written by Glencoe Software's
 [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility and currently under
-review for inclusion in the OME-NGFF specification - see [here](https://github.com/ome/ngff/pull/112).
+review for inclusion in the OME-NGFF specification - see [the relevant discussion on GitHub](https://github.com/ome/ngff/pull/112).
 OME-NGFF import is currently only available using the command-line interface, see the
 [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
 for more details.

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -20,7 +20,7 @@ the documentation for the stable version is available from <https://omero.readth
 
 ### Installing the Software:
 
-For full details of the changes with the OMERO 5.6 series see the
+For full details of the changes included in the OMERO 5.6 series see the
 [OMERO 5.6.0]({{ site.baseurl }}/2020/01/15/omero-5-6-0.html) release
 announcement. Full documentation for this release is available
 under <https://omero.readthedocs.io/en/stable/>.

--- a/_posts/2022-06-29-omero-5-6-5.md
+++ b/_posts/2022-06-29-omero-5-6-5.md
@@ -19,7 +19,7 @@ OME-NGFF import is currently only available using the command-line interface, se
 [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
 for more details.
 
-Note the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
+Note that the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
 
 Finally, the OMERO.server technical documentation has been migrated to Read the Docs and
 the documentation for the stable version is available from <https://omero.readthedocs.io/en/stable/>.

--- a/_posts/2022-06-30-omero-5-6-5.md
+++ b/_posts/2022-06-30-omero-5-6-5.md
@@ -6,7 +6,7 @@ title: Release of OMERO.server 5.6.5
 Today we are releasing OMERO.server 5.6.5 which includes:
 
 -   a new [omero.pixeldata.max_plane_float_override](https://omero.readthedocs.io/en/v5.6.5/sysadmins/config.html#omero.pixeldata.max_plane_float_override)
-    server configuration allowing to control the pyramidal requirement for floating-point images
+    server configuration, see the [large floating-point images limitations section](https://omero.readthedocs.io/en/v5.6.5-2/sysadmins/limitations.html#float-limitations) for more details
 -   an upgrade of Bio-Formats to the last released version 6.10.0, see the [release announcement]({{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html).
 -   the [OMEZarrReader](https://github.com/ome/ZarrReader/) version 0.3.0
 

--- a/_posts/2022-06-30-omero-5-6-5.md
+++ b/_posts/2022-06-30-omero-5-6-5.md
@@ -5,7 +5,8 @@ title: Release of OMERO.server 5.6.5
 
 Today we are releasing OMERO.server 5.6.5 which includes:
 
--   a new server configuration allowing to control the pyramidal requirement for floating-point images
+-   a new [omero.pixeldata.max_plane_float_override](https://omero.readthedocs.io/en/v5.6.5/sysadmins/config.html#omero.pixeldata.max_plane_float_override)
+    server configuration allowing to control the pyramidal requirement for floating-point images
 -   an upgrade of Bio-Formats to the last released version 6.10.0, see the [release announcement]({{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html).
 -   the [OMEZarrReader](https://github.com/ome/ZarrReader/) version 0.3.0
 

--- a/_posts/2022-06-30-omero-5-6-5.md
+++ b/_posts/2022-06-30-omero-5-6-5.md
@@ -13,8 +13,9 @@ The OMEZarrReader inclusion allows the server to import imaging data written acc
 [OME-NGFF](https://ngff.openmicroscopy.org/) specification. The reader supports OME-NGFF datasets
 for all published versions of the specification (up to and including 0.4) and reads OME-XML
 metadata stored using the layout written by Glencoe Software's
-[bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility and currently under
-review for inclusion in the OME-NGFF specification - see [the relevant discussion on GitHub](https://github.com/ome/ngff/pull/112).
+[bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) utility. This
+metadata layout is currently being reviewed for formal inclusion into the OME-NGFF specification - see
+[the relevant discussion on GitHub](https://github.com/ome/ngff/pull/112).
 OME-NGFF import is currently only available using the command-line interface, see the
 [limitations](https://omero.readthedocs.io/en/stable/sysadmins/limitations.html#ngff-limitations) page
 for more details.

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ many_thanks:
             <span>
             <i class="fa fa-bullhorn"></i>
             On 2022-06-29 we released
-            <a class="styled-link" href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html">
+            <a class="styled-link" href="{{ site.baseurl }}/2022/06/30/omero-5-6-5.html">
             OMERO.server 5.6.5</a>.
             </span>
         </section>
@@ -66,7 +66,7 @@ many_thanks:
               <br>
               <a href="{{ site.baseurl }}/events/" class="large button sites-button btn-red">Upcoming Workshops</a>
               &nbsp;&nbsp;
-              <a href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html" class="large button sites-button btn-red">Latest release</a>
+              <a href="{{ site.baseurl }}/2022/06/30/omero-5-6-5.html" class="large button sites-button btn-red">Latest release</a>
               <br>
               <a href="{{ site.baseurl }}/events/ome-community-meeting-2021/" class="large button sites-button btn-blue">OME 2021 Community Meeting</a>
               </div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ many_thanks:
             <i class="fa fa-bullhorn"></i>
             On 2022-06-29 we released
             <a class="styled-link" href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html">
-            OMERO 5.6.5</a>.
+            OMERO.server 5.6.5</a>.
             </span>
         </section>
         <!-- end banner announcement -->

--- a/index.html
+++ b/index.html
@@ -49,9 +49,9 @@ many_thanks:
         <section class="announcement bg-ome-red">
             <span>
             <i class="fa fa-bullhorn"></i>
-            On 2022-05-31 we released 
-            <a class="styled-link" href="{{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html">
-            Bio-Formats 6.10.0</a>.
+            On 2022-06-29 we released
+            <a class="styled-link" href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html">
+            OMERO 5.6.5</a>.
             </span>
         </section>
         <!-- end banner announcement -->
@@ -66,7 +66,7 @@ many_thanks:
               <br>
               <a href="{{ site.baseurl }}/events/" class="large button sites-button btn-red">Upcoming Workshops</a>
               &nbsp;&nbsp;
-              <a href="{{ site.baseurl }}/2022/05/31/bio-formats-6-10-0.html" class="large button sites-button btn-red">Latest release</a>
+              <a href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html" class="large button sites-button btn-red">Latest release</a>
               <br>
               <a href="{{ site.baseurl }}/events/ome-community-meeting-2021/" class="large button sites-button btn-blue">OME 2021 Community Meeting</a>
               </div>

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -8,8 +8,8 @@ meta_description: Download the latest version of OMERO here.
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.majorversion }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2020/10/01/omero-5-6-3.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
-                <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/" target="_blank" class="hero-link">Read the Docs</a>
+                <a href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="https://omero.readthedocs.io/en/stable/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>
 

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -8,7 +8,7 @@ meta_description: Download the latest version of OMERO here.
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.majorversion }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2022/06/29/omero-5-6-5.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2022/06/30/omero-5-6-5.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://omero.readthedocs.io/en/stable/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>


### PR DESCRIPTION
Announcement for the OMERO.server binaries published under https://github.com/ome/openmicroscopy/releases/tag/v5.6.5