### PR TITLE
bump omero-matlab version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ omero:
  insight:
   version: 5.7.2
  matlab:
-  version: 5.5.5
+  version: 5.5.6
 
 omecommoncpp:
   version: 5.5.0


### PR DESCRIPTION
Bump version to match https://github.com/ome/omero-matlab/releases/tag/v5.5.6