### PR TITLE
OME2022: deactivate banner and swap OME2021 links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
                         <li><a href="{{ site.baseurl }}/teams/">Our Team</a></li>
                         <li><a href="{{ site.baseurl }}/explore/">What We Can Do</a></li>
                         <li><a href="{{ site.baseurl }}/news/">What We’re Up To</a></li>
-                        <li><a href="{{ site.baseurl }}/events/ome-community-meeting-2021/">OME 2021</a></li>
+                        <li><a href="{{ site.baseurl }}/events/ome-community-meeting-2022/">OME 2022</a></li>
                         <li class="hide-for-large-only">&nbsp;</li>
                     </ul>
                 </div>

--- a/_includes/navbar-main.html
+++ b/_includes/navbar-main.html
@@ -20,7 +20,7 @@
                             <li><a href="{{ site.baseurl }}/citing-ome/">Citing OME</a></li>
                             <li><a href="{{ site.baseurl }}/artwork/">Artwork</a></li>
                             <li><a href="{{ site.baseurl }}/training/">Training</a></li>
-                            <li><a href="{{ site.baseurl }}/events/ome-community-meeting-2021/">OME 2021</a></li>
+                            <li><a href="{{ site.baseurl }}/events/ome-community-meeting-2022/">OME 2022</a></li>
                         </ul>
                     </li>
                     <li class="has-submenu"><a href="{{ site.baseurl }}/news/">News</a>

--- a/events/index.html
+++ b/events/index.html
@@ -11,7 +11,7 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
         <div id="community-posts" class="row">
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> November 8-17, 2022</h6>
-                <h2><a href="ome-community-meeting-november-2022.html">OME 2022 Community Meeting, Dundee, online</a></h2>
+                <h2><a href="ome-community-meeting-2022/">OME 2022 Community Meeting, Dundee, online</a></h2>
                 <p class="card-caption">Online meeting of community and friends, in the form of five 2-hour sessions, November 8-17, 2022</p>
             </div>
             <hr class="medium-8">

--- a/events/ome-community-meeting-2022/index.html
+++ b/events/ome-community-meeting-2022/index.html
@@ -3,6 +3,8 @@ layout: news-events
 filename: events
 title: November 2022 OME Meeting of community and friends
 main-blurb: 2-hour online technical sessions on new OME-related topics.
+redirect_from:
+  - /events/ome-community-meeting-november-2022.html
 ---
      <hr class="whitespace">
         <div class="row">

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@ many_thanks:
 ---
 
         <!-- begin banner announcement -->
+        <!--
         <section class="announcement bg-ome-red">
             <span>
             <i class="fa fa-bullhorn"></i>
@@ -54,6 +55,7 @@ many_thanks:
             Bio-Formats 6.11.0</a>.
             </span>
         </section>
+        -->
         <!-- end banner announcement -->
 
         <!-- begin standard header to be hidden when event like community meeting is announced -->
@@ -75,13 +77,13 @@ many_thanks:
 
         <!-- end standard header -->
         <!-- begin marketing header -->
-        <!-- header class="marketing-hero" id="bg-hero-ome-community-meeting-2020">
+        <header class="marketing-hero" id="bg-hero-ome-community-meeting-2022">
             <div class="row homepage text-center">
                 <div class="small-12 columns bg-image-text-container">
-                    <h1 class="small-12">OME 2021 Community Meeting</h1>
-                    <h5 class="small-10 small-offset-1 medium-4 medium-offset-4 bold text-shadow-light">Join us from June 08th to June 11th 2021 for our virtual community meeting.</h5>
+                    <h1 class="small-12">OME 2022 Community Meeting</h1>
+                    <h5 class="small-10 small-offset-1 medium-4 medium-offset-4 bold text-shadow-light">Join us from November 08th to 17th 2022 for our virtual community meeting.</h5>
                     <br>
-                    <a href="{{ site.baseurl }}/events/ome-community-meeting-2021/" class="large button sites-button btn-red">View the programme</a>
+                    <a href="{{ site.baseurl }}/events/ome-community-meeting-2022/" class="large button sites-button btn-red">View the programme</a>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@ many_thanks:
 
         <!-- end standard header -->
         <!-- begin marketing header -->
+        <!--
         <header class="marketing-hero" id="bg-hero-ome-community-meeting-2022">
             <div class="row homepage text-center">
                 <div class="small-12 columns bg-image-text-container">
@@ -87,7 +88,8 @@ many_thanks:
                 </div>
             </div>
         </header>
-        < end marketing header -->
+        -->
+        <!-- end marketing header -->
 
         <!-- begin OMERO highlight -->
         <hr class="whitespace">

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ many_thanks:
               &nbsp;&nbsp;
               <a href="{{ site.baseurl }}/2022/10/13/bio-formats-6-11-0.html" class="large button sites-button btn-red">Latest release</a>
               <br>
-              <a href="{{ site.baseurl }}/events/ome-community-meeting-november-2022.html" class="large button sites-button btn-red">OME 2022 Community Meeting</a>
+              <a href="{{ site.baseurl }}/events/ome-community-meeting-2022/" class="large button sites-button btn-red">OME 2022 Community Meeting</a>
               </div>
             </div>
         </header>


### PR DESCRIPTION
Updated/fixed a few different locations:

* Dropped the current release banner

* Updated the footer
![Screen Shot 2022-10-24 at 08 21 31](https://user-images.githubusercontent.com/88113/197460532-d10ba401-5dfe-43dd-9c07-32de48f1bf48.png)

* Updated the navigation menu
![Screen Shot 2022-10-24 at 08 21 43](https://user-images.githubusercontent.com/88113/197460559-dd5222ff-2d97-4759-9879-6dbf008105bf.png)

