### PR TITLE
temporarily remove the external checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ docker pull jekyll/builder:pages
 docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
 # Report 4xx status codes except 429 errors (Too Many Requests)
 # typically sent by GitHub while linkchecking the downloads
-docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --only_4xx --ignore-status-codes "429" --ignore-files "/site/minutes/,/minutes/" --ignore-urls "/twitter.com/,/uk1s3.embassy.ebi.ac.uk/,/biorxiv.org/,/meded.hms.harvard.edu/" --no-enforce-https --allow-missing-href --typhoeus='{"headers" : {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/91.0.4472.164 Safari/537.36"}}'
+docker run --rm -v $(pwd)/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --disable_external --only_4xx --ignore-status-codes "429" --ignore-files "/site/minutes/,/minutes/" --ignore-urls "/twitter.com/,/uk1s3.embassy.ebi.ac.uk/,/biorxiv.org/,/meded.hms.harvard.edu/" --no-enforce-https --allow-missing-href --typhoeus='{"headers" : {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/91.0.4472.164 Safari/537.36"}}'
 
 # Test file existence
 echo "Checking Schemas existence"


### PR DESCRIPTION
remove the external check
I have tried other options like ``--swap-urls`` but without much luck.
When we have the site deployed we can remove the flag