### PR TITLE
Release omero 5.6.6

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,9 +38,9 @@ bf:
  version: 6.11.1
 
 omero:
- version: 5.6.5
+ version: 5.6.6
  majorversion: 5.6
- build: b233
+ build: b236
  insight:
   version: 5.7.2
  matlab:

--- a/_posts/2018-03-26-idr.md
+++ b/_posts/2018-03-26-idr.md
@@ -43,7 +43,7 @@ data descriptor by
 of Rho GTPases in triple negative breast cancer.
 
 The *Scientific Data* repository list is
-[mirrored](https://www.springernature.com/gp/authors/research-data-policy/repositories/12327124)
+[mirrored](https://www.springernature.com/gp/authors/research-data-policy/repositories-bio/12327160)
 for use by other Springer Nature journals and is therefore also available for
 use by authors submitting to other Springer Nature journals. As an example, an
 article published by [Kilpinen *et al*](http://dx.doi.org/10.1038/nature22403)

--- a/_posts/2022-12-13-omero-5-6-6.md
+++ b/_posts/2022-12-13-omero-5-6-6.md
@@ -7,7 +7,7 @@ Today we are releasing OMERO.server 5.6.6 which includes:
 
 - a new property [omero.qa.feedback](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.qa.feedback) to configure the QA system the feedback is submitted to.
 - the option for [omero.server.nodedescriptors](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.server.nodedescriptors) to be queried from a client.
-- an enhancement of the Command line importer developer user experience
+- an enhancement of the Java Command line importer developer user experience
 -  an upgrade of Bio-Formats to the last released version 6.11.1, see the [release announcement]({{ site.baseurl }}/2022/12/01/bio-formats-6-11-1.html).
 
 

--- a/_posts/2022-12-13-omero-5-6-6.md
+++ b/_posts/2022-12-13-omero-5-6-6.md
@@ -8,7 +8,7 @@ Today we are releasing OMERO.server 5.6.6 which includes:
 - a new property [omero.qa.feedback](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.qa.feedback) to configure the QA system the feedback is submitted to.
 - the option for [omero.server.nodedescriptors](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.server.nodedescriptors) to be queried from a client.
 - an enhancement of the Java Command line importer developer user experience
--  an upgrade of Bio-Formats to the last released version 6.11.1, see the [release announcement]({{ site.baseurl }}/2022/12/01/bio-formats-6-11-1.html).
+- an upgrade of Bio-Formats to the last released version 6.11.1, see the [release announcement]({{ site.baseurl }}/2022/12/01/bio-formats-6-11-1.html).
 
 
 

--- a/_posts/2022-12-13-omero-5-6-6.md
+++ b/_posts/2022-12-13-omero-5-6-6.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: Release of OMERO.server 5.6.6
+---
+
+Today we are releasing OMERO.server 5.6.6 which includes:
+
+- a new property [omero.qa.feedback](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.qa.feedback) to configure the QA system the feedback is submitted to.
+- the option for [omero.server.nodedescriptors](https://omero.readthedocs.io/en/v5.6.6/sysadmins/config.html#omero.server.nodedescriptors) to be queried from a client.
+- an enhancement of the Command line importer developer user experience
+-  an upgrade of Bio-Formats to the last released version 6.11.1, see the [release announcement]({{ site.baseurl }}/2022/12/01/bio-formats-6-11-1.html).
+
+
+
+Note that the Bio-Formats Memoizer cache **will be invalidated** on upgrade from earlier OMERO.server versions.
+
+Finally, the OMERO.server technical documentation has been migrated to Read the Docs and
+the documentation for the stable version is available from <https://omero.readthedocs.io/en/stable/>.
+
+### Installing the Software:
+
+For full details of the changes included in the OMERO 5.6 series see the
+[OMERO 5.6.0]({{ site.baseurl }}/2020/01/15/omero-5-6-0.html) release
+announcement. Full documentation for this release is available
+under <https://omero.readthedocs.io/en/v5.6.5/>.
+
+This release has been tested with
+[OMERO.py 5.13.1](https://pypi.org/project/omero-py/5.13.1/) and
+[OMERO.web 5.16.0](https://pypi.org/project/omero-web/5.16.0/). We
+recommend that you upgrade OMERO.py and OMERO.web accordingly on your deployments.
+
+Official Docker images are available as usual on Docker Hub with either
+the latest or the 5.6 tag:
+
+* <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
+* <https://hub.docker.com/r/openmicroscopy/omero-server>
+
+You are invited to discuss this announcement on
+[the image.sc forum](https://forum.image.sc/tags/c/data-management/omero).
+
+All the best with your upgrades,
+
+The OME Team

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -8,7 +8,7 @@ meta_description: Download the latest version of OMERO here.
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.majorversion }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2022/06/30/omero-5-6-5.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2022/12/13/omero-5-6-6.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://omero.readthedocs.io/en/stable/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>

--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -105,7 +105,7 @@ meta_description: Download the latest version of OMERO here.
                         <h5>Server (Ice 3.6)</h5>
                         <h6>OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">View installation guides in <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/sysadmins/index.html" target="_blank">System Administrator documentation</a>.</p>
-                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.server-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (260 MB)</a>
+                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.server-{{ site.omero.version }}-ice36.zip" class="button hollow small"><i class="fa fa-download"></i> Download (260 MB)</a>
                     </div>
                 </div>
             </div>
@@ -137,7 +137,7 @@ meta_description: Download the latest version of OMERO here.
                         <h5>Java (Ice 3.6)</h5>
                         <h6>OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip</h6>
                         <p class="card-caption">The OMERO Java documentation is available to read on the web <a href="https://docs.openmicroscopy.org/omero/{{ site.omero.version }}/developers/Java.html">here</a>.</p>
-                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.java-{{ site.omero.version }}-ice36-{{ site.omero.build }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (125 MB)</a>
+                        <a href="https://github.com/ome/openmicroscopy/releases/download/v{{ site.omero.version }}/OMERO.java-{{ site.omero.version }}-ice36.zip" class="button hollow small"><i class="fa fa-download"></i> Download (125 MB)</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Add entry for 5.6.6
Added link to the new property so the documentation will need to be released before so the linkcheck can be green