### PR TITLE
Add mastodon link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -44,7 +44,7 @@
         <meta name="theme-color" content="#ffffff">
 
         <!-- Mastodon -->
-        <link rel="me" href="https://fosstodon.org/@ome/>
+        <link rel="me" href="https://fosstodon.org/@ome"/>
 
 {% include css.html %}
     </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,6 +43,9 @@
         <meta name="msapplication-TileColor" content="#2b5797">
         <meta name="theme-color" content="#ffffff">
 
+        <!-- Mastodon -->
+        <link rel="me" href="https://fosstodon.org/@ome/>
+
 {% include css.html %}
     </head>
 


### PR DESCRIPTION
This is to make the link on the [profile](https://fosstodon.org/@ome) green, meaning verified.

![Screenshot 2023-02-03 at 15 18 49](https://user-images.githubusercontent.com/88113/216626102-580a6cfc-0695-43fd-8386-58ac7fb3ac7a.png)
