### PR TITLE
Add announcement for OMERO.web 5.18.0

### DIFF
--- a/_posts/2023-02-14-omero-web-5.18.0.md
+++ b/_posts/2023-02-14-omero-web-5.18.0.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: Release of OMERO.web 5.18.0
+intro-blurb: The OME team is pleased to announce the release of OMERO.web 5.18.0
+---
+
+Today we are releasing OMERO.web 5.18.0, which includes support for a new
+session serializer and a number of bugfixes and upgrades of third-party libraries.
+
+Please see the [upgrade instructions](https://github.com/ome/omero-web/blob/v5.18.0/UPGRADING.md) for plugin developers and 
+the [OMERO.web changelog](https://github.com/ome/omero-web/blob/v5.18.0/CHANGELOG.md).
+
+### Installing the Software
+
+OMERO.web 5.18.0 is available from PyPI - see 
+[here](https://pypi.org/project/omero-web/5.18.0/).
+
+Official Docker images are available as usual on Docker Hub with either
+the latest or the 5.18 tag:
+
+* <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
+* <https://hub.docker.com/r/openmicroscopy/omero-server>
+
+You are invited to discuss this announcement on
+[the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).
+
+All the best with your upgrades,
+
+The OME Team


### PR DESCRIPTION
Will move out of draft mode once Docker releases are ready.