### PR TITLE
Add links to resources, use past tense

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -22,7 +22,7 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
             </div>
             <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
-                <h6><i class="fa fa-star event-future"></i> February 15, 2023</h6>
+                <h6><i class="fa fa-calendar"></i> February 15, 2023</h6>
                 <h2><a href="workshops-lci-karolinska-february-2023.html">OMERO and OMERO.figure Workshop, LCI</a></h2>
                 <p class="card-caption">Online 2 hour workshop on how to use OMERO and OMERO.figure with emphasis on publication.</p>
             </div>

--- a/events/workshops-lci-karolinska-february-2023.html
+++ b/events/workshops-lci-karolinska-february-2023.html
@@ -2,7 +2,7 @@
 layout: news-events
 filename: events
 title: February 2023 OMERO and OMERO.figure workshop
-main-blurb: The OME Team gives a public workshop on OMERO and OMERO.figure as a part of a three-week course organized by LCI at Karolinska Institutet.
+main-blurb: The OME Team gave a public workshop on OMERO and OMERO.figure as a part of a three-week course organized by LCI at Karolinska Institutet.
 ---          
      <hr class="whitespace">
         <div class="row">
@@ -12,7 +12,7 @@ main-blurb: The OME Team gives a public workshop on OMERO and OMERO.figure as a 
         </div>
         <div class="row">
             <div class="column">
-                <h2 class="event-day">Location: Stockholm, OMERO and OMERO.figure workshop is held remotely
+                <h2 class="event-day">Location: Stockholm, OMERO and OMERO.figure workshop was held remotely
             </div>
         </div>
         <div class="row">
@@ -24,14 +24,14 @@ main-blurb: The OME Team gives a public workshop on OMERO and OMERO.figure as a 
         <div class="row">
             <div class="column">
                 <h2 class="event-day">Duration: 2 hours </h2>
-                <p class="event-day-description">This online course focuses on explanation of basics of OMERO and OMERO.figure. Both parts will give encouragement for hands-on work with concrete examples and tasks. The main theme of the workshop is the publication possibilities in OMERO and OMERO.figure.
+                <p class="event-day-description">This online course focused on explanation of basics of OMERO and OMERO.figure. Both parts gave encouragement for hands-on work with concrete examples and tasks. The main theme of the workshop was the publication possibilities in OMERO and OMERO.figure.
                 </p>
             </div>
         </div>
 		<hr class="whitespace">
         <div class="row">
             <div class="column">
-                <h2 class="event-day">Resources available under: TBD
+                <h2 class="event-day">Resources available: <a href="https://downloads.openmicroscopy.org/presentations/2023/Karolinska_LCI/" target="_blank">Presentation & walkthrough</a> and a video <a href="https://youtu.be/I2GoGONhMS4?t=235" target="_blank"> recording of the workshop</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Updating the just finished LCI workshop event

1. Adding Link to the presentation, walkthrough and YouTube video
2. Putting the text into past tense


cc @joshmoore 

built at https://snoopycrimecop.github.io/www.openmicroscopy.org/events/workshops-lci-karolinska-february-2023.html