### PR TITLE
Update broken npsc link

### DIFF
--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -39,7 +39,7 @@ meta_description: Commercial licenses and deployments of our software are availa
                 <ul class="dev-ops-links">
                     <li><a href="http://www.ascb.org/" target="_blank">American Society of Cell Biology</a></li>
                     <li><a href="http://hms.harvard.edu/" target="_blank">Harvard Medical School</a></li>
-                    <li><a href="http://npsc.ac.uk" target="_blank">National Phenotypic Screening Centre</a></li>
+                    <li><a href="https://www.dundee.ac.uk/locations/national-phenotypic-screening-centre-npsc" target="_blank">National Phenotypic Screening Centre</a></li>
                     <li><a href="https://www.maastrichtuniversity.nl" target="_blank">Maastricht University</a></li>
                     <li><a href="http://www.vrtx.com" target="_blank">Vertex</a></li>
                     <li>...and several others we can't disclose.</li>


### PR DESCRIPTION
While running the tests for https://github.com/ome/www.openmicroscopy.org/pull/645 it highlighted that the  http://npsc.ac.uk/ link was broken. The updated link is the closest match I could find for a replacement.