### PR TITLE
Fix Docker link

### DIFF
--- a/_posts/2021-03-17-omero-web-5.9.0.md
+++ b/_posts/2021-03-17-omero-web-5.9.0.md
@@ -25,7 +25,7 @@ Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.6 tag:
 
 * <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
-* <https://hub.docker.com/r/openmicroscopy/omero-server>
+* <https://hub.docker.com/r/openmicroscopy/omero-web>
 
 You are invited to discuss this announcement on
 [the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).

--- a/_posts/2021-10-14-omero-web-5.11.0.md
+++ b/_posts/2021-10-14-omero-web-5.11.0.md
@@ -23,7 +23,7 @@ Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.6 tag:
 
 * <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
-* <https://hub.docker.com/r/openmicroscopy/omero-server>
+* <https://hub.docker.com/r/openmicroscopy/omero-web>
 
 You are invited to discuss this announcement on
 [the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).

--- a/_posts/2022-03-21-omero-web-5.14.0.md
+++ b/_posts/2022-03-21-omero-web-5.14.0.md
@@ -16,7 +16,7 @@ Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.14 tag:
 
 * <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
-* <https://hub.docker.com/r/openmicroscopy/omero-server>
+* <https://hub.docker.com/r/openmicroscopy/omero-web>
 
 You are invited to discuss this announcement on
 [the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).

--- a/_posts/2023-02-14-omero-web-5.18.0.md
+++ b/_posts/2023-02-14-omero-web-5.18.0.md
@@ -19,7 +19,7 @@ Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.18 tag:
 
 * <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
-* <https://hub.docker.com/r/openmicroscopy/omero-server>
+* <https://hub.docker.com/r/openmicroscopy/omero-web>
 
 You are invited to discuss this announcement on
 [the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).

--- a/_posts/2023-03-20-omero-web-5.19.0.md
+++ b/_posts/2023-03-20-omero-web-5.19.0.md
@@ -19,7 +19,7 @@ Official Docker images are available as usual on Docker Hub with either
 the latest or the 5.19 tag:
 
 * <https://hub.docker.com/r/openmicroscopy/omero-web-standalone>
-* <https://hub.docker.com/r/openmicroscopy/omero-server>
+* <https://hub.docker.com/r/openmicroscopy/omero-web>
 
 You are invited to discuss this announcement on
 [the image.sc forum](https://forum.image.sc/tags/c/data-management/29/omero).


### PR DESCRIPTION
Link to `omero-web` instead of `omero-server` in older announcements, similar to the change for the latest announcement in https://github.com/ome/www.openmicroscopy.org/pull/648/commits/23c255fa12548841f78620f94b938fb406f00ae1