### PR TITLE
Update contributor names

### DIFF
--- a/_data/contributors.json
+++ b/_data/contributors.json
@@ -26,7 +26,7 @@
                 }
             ],
             "familyName": "Ehrenfeuchter",
-            "givenName": "Niko",
+            "givenName": "Nikolaus",
             "sameAs": "https://github.com/ehrenfeu"
         },
         {
@@ -148,7 +148,7 @@
                 }
             ],
             "familyName": "Nakamura",
-            "givenName": "Kouchi",
+            "givenName": "Kouichi",
             "sameAs": "https://github.com/kouichi-c-nakamura"
         },
         {
@@ -175,7 +175,7 @@
                     "url": "https://www.maastrichtuniversity.nl"
                 }
             ],
-            "familyName": "Van Schayck",
+            "familyName": "van Schayck",
             "givenName": "Paul",
             "sameAs": "https://github.com/PaulVanSchayck"
         },


### PR DESCRIPTION
Driven by the ongoing mailmap work, this fix spelling typos and update names to match the canonical real names