### PR TITLE
Update omero.search property description

### DIFF
--- a/_posts/2023-03-20-omero-5-6-7.md
+++ b/_posts/2023-03-20-omero-5-6-7.md
@@ -7,7 +7,7 @@ intro-blurb: The OME team is pleased to announce the release of OMERO.server 5.6
 Today we are releasing OMERO.server 5.6.7 which includes:
 
 - addressing performance issues when indexing fileset
-- a new property [omero.search.max_fileset_size](https://omero.readthedocs.io/en/v5.6.7/sysadmins/config.html#omero.search.max_fileset_size) to configure the QA system the feedback is submitted to.
+- a new property [omero.search.max_fileset_size](https://omero.readthedocs.io/en/v5.6.7/sysadmins/config.html#omero.search.max_fileset_size) to indicate the maximum size of the fileset to be considered for indexing
 - running the PixelDataThread Application events in SYSTEM Thread pool
 - declaring logback-classic as explicit dependency and set to 1.2.x
 - an upgrade of Bio-Formats to the last released version 6.12.0, see the [release announcement]({{ site.baseurl }}/2023/02/14/bio-formats-6-12-0.html).


### PR DESCRIPTION
Fixes an incorrect property description in the release notes of OMERO 5.6.7 noticed by @chris-allan 

Was introduced in https://github.com/ome/www.openmicroscopy.org/pull/641 which escaped review and was likely a copy-paste from https://github.com/ome/www.openmicroscopy.org/pull/626