### PR TITLE
Fix version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ bf:
  version: 7.0.0
 
 omero:
- version: 5.6.7
+ version: 5.6.8
  majorversion: 5.6
  insight:
   version: 5.8.1


### PR DESCRIPTION
* Bump omero version to 5.6.8

i will look into bumping ome-model into a separate PR since now point to readthedocs and we now use  versioning using date for ome-model see https://ome-model.readthedocs.io/en/2023.06.29/