### PR TITLE
Hide banner completely

### DIFF
--- a/_includes/navbar-sub-omero.html
+++ b/_includes/navbar-sub-omero.html
@@ -1,7 +1,9 @@
 <!-- begin banner announcement -->
+<!--
 <section class="announcement">
     <span><i class="fa fa-bullhorn"></i> IMPORTANT: Critical security release - OMERO 5.6.1 now available - <a class="styled-link" href="{{ site.baseurl }}/2020/03/25/omero-5-6-1.html">Read the Announcement</a></span>
 </section>
+-->
 <!-- end banner announcement -->
 
 <div class="title-bar" data-responsive-toggle="omero-menu" data-hide-for="medium">


### PR DESCRIPTION
Previously, the text of the banner was simply white (see PR screenshot). For now, commenting out the block will fix the issue.

![image](https://github.com/ome/www.openmicroscopy.org/assets/88113/a99ddea3-06ac-4713-a30d-4103d3212ad9)


Thanks to @eik-dahms for the heads up.