### PR TITLE
Remove latest release button

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,6 @@ many_thanks:
               <br>
               <a href="{{ site.baseurl }}/events/" class="large button sites-button btn-red">Upcoming Workshops</a>
               &nbsp;&nbsp;
-              <a href="{{ site.baseurl }}/2024/02/08/bio-formats-7-2-0.html" class="large button sites-button btn-red">Latest release</a>
               <br>
               <a href="{{ site.baseurl }}/events/ome-community-meeting-2024/" class="large button sites-button btn-blue">OME 2024 Community Meeting</a>
               </div>


### PR DESCRIPTION
As discussed in Slack. The button is hard to update as it requires a manual intervetion.

cc @dgault @jburel 