### PR TITLE
Update to 5.6.12 release notes

### DIFF
--- a/omero/downloads/index.html
+++ b/omero/downloads/index.html
@@ -8,7 +8,7 @@ meta_description: Download the latest version of OMERO here.
         <div class="callout large primary" id="bg-image-omero">
             <div class="row column text-center">
                 <h1>OMERO {{ site.omero.majorversion }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2022/12/13/omero-5-6-6.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2024/07/29/omero-5.6.12.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://omero.readthedocs.io/en/stable/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>


### PR DESCRIPTION
Updates the release note link on the downloads page for OMERO to point to the latest version (5.6.12). It has been at 5.6.6 for some time and I'm pretty sure that's not intended.

It's also not great that we have been oscillating back and forth between dot (ex. `2024-05-10-omero-5.6.11.md`) and dash (ex. `2023-12-18-omero-5-6-10.md`) separated naming for the posts but the horse has bolted on that I'm afraid.

Codifying both is something to ensure is in the release processes for the various components going forward. The release note links will then always get updated and their page URLs are easier to predict.

/cc @kkoz, @knabar, @melissalinkert 