### PR TITLE
remove link to qa.openmicroscopy.org.uk for demo account

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -24,10 +24,10 @@ meta_description: Explore OME products in action and see them in use in labs and
         <div class="row">
             <img class="medium-3 medium-offset-1 columns" alt="OMERO for Scientists" src="{{ site.baseurl }}/img/icons/user-groups_scientists.svg">
             <div class="medium-8 columns">
-                <p>Sign up for our <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">OMERO demo server</a> to test out the functionality with your own data. If happy, <a href="{{ site.baseurl }}/omero/institution/getting-started.html"> check how to start with OMERO in your institution.</a></p>
+                <p>Sign up for our <a href="https://www.openmicroscopy.org/qa2/registry/demo_account/">OMERO demo server</a> to test out the functionality with your own data. If happy, <a href="{{ site.baseurl }}/omero/institution/getting-started.html"> check how to start with OMERO in your institution.</a></p>
                 <p><a href="{{ site.baseurl }}/bio-formats/">Bio-Formats</a> lets you read image data from Java, <a href="https://imagej.net/Welcome" target="_blank">ImageJ</a>/<a href="https://fiji.sc/" target="_blank">Fiji</a>, GNU Octave/MATLAB, Python and R. If you're already using Fiji, it comes bundled with the <a href="https://docs.openmicroscopy.org/bio-formats/{{ site.bf.version }}/users/index.html#using-bio-formats-with-imagej-and-fiji">Bio-Formats plugin</a> automatically.</p>
                 <hr class="invisible">
-                <p><a class="button small" href="http://qa.openmicroscopy.org.uk/registry/demo_account/">Sign up for Demo Server</a>
+                <p><a class="button small" href="https://www.openmicroscopy.org/qa2/registry/demo_account/">Sign up for Demo Server</a>
             </div>
         </div>
         <!-- end section for OMERO for Scientists -->

--- a/omero/features/utility/index.html
+++ b/omero/features/utility/index.html
@@ -45,7 +45,7 @@ meta_description: Fully customize your OMERO experience.
                 <h4>Quality Assurance</h4>
                 <p>Feedback system that allows users to send comments, bugs,
                     or data files, and to track responses and updates.</p>
-                <a class="button hollow tiny" href="http://qa.openmicroscopy.org.uk/" target="_blank">Read more</a>
+                <a class="button hollow tiny" href="https://www.openmicroscopy.org/qa2/" target="_blank">Read more</a>
             </div>
             <div class="omero-feature-container tall-content  column text-center">
                 <img class="thumbnail omero-feature" alt="OMERO feature" src="{{ site.baseurl }}/img/icons/omero-features-icons_personalize.svg">

--- a/omero/scientists/getting-started.html
+++ b/omero/scientists/getting-started.html
@@ -18,7 +18,7 @@ meta_description: To help you get started learning about OMERO, take a look at t
                     <div class="card-section">
                         <h4 class="text-center">Try out the Demo server</h4>
                         <i class="fa fa-book fa-5x icon-red"></i>
-                        <p class="card-caption"><a href="http://qa.openmicroscopy.org.uk/registry/demo_account/" target="_blank">Register</a> to try OMERO before committing any IT resources to getting a server set up. This guide includes terms of use and takes you through connecting to the server.</p>
+                        <p class="card-caption"><a href="https://www.openmicroscopy.org/qa2/registry/demo_account/" target="_blank">Register</a> to try OMERO before committing any IT resources to getting a server set up. This guide includes terms of use and takes you through connecting to the server.</p>
                         <div class="text-center"><a class="button small" href="https://www.openmicroscopy.org/explore/" target="_blank">Read the Guide</a></div>
                     </div>
                 </div>

--- a/support/index.html
+++ b/support/index.html
@@ -45,7 +45,7 @@ meta_description: A collection of support resources to help the OME community.
                         <i class="border-blue icon-blue fa fa-life-ring fa-2x"></i>
                         <h4>OMERO.qa</h4>
                         <p class="card-caption">Submit files and bug reports for assistance from the developer team.<br><br></p>
-                        <a href="http://qa.openmicroscopy.org.uk" target="_blank" class="btn-blue button small">Visit the Site</a>
+                        <a href="https://www.openmicroscopy.org/qa2/" target="_blank" class="btn-blue button small">Visit the Site</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
As part of the on-going migration of QA,
this PR removes the link to qa.openmicroscopy.org.uk for demo account
Point to qa2 