### PR TITLE
GitHub Actions version upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Create website archive
         run: tar -zcvf ${{ github.event.repository.name }}.tar.gz -C _site ./
       - name: Upload website archive as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}.tar.gz
           path: ${{ github.event.repository.name }}.tar.gz
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download website archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.event.repository.name }}.tar.gz
       - name: Create checksum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build static website


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Supersedes https://github.com/ome/www.openmicroscopy.org/pull/747 (by upgrading the download and the upgrade actions concurrently)