### PR TITLE
Add advisory for the assessment of the impact of CVE-2022-22950

### DIFF
--- a/_layouts/security-advisory.html
+++ b/_layouts/security-advisory.html
@@ -14,4 +14,9 @@ layout: default
     <a id="back-to-top" href="{{ site.baseurl }}/security/advisories/"><i class="fa fa-arrow-left"></i> back to Advisories</a>
 </div>
 
+<hr class="whitespace">
+<div class="row">
+    <div class="columns">
 {{ content }}
+    </div>
+</div>

--- a/security/advisories/2012-SV1/index.html
+++ b/security/advisories/2012-SV1/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2014-SV1/index.html
+++ b/security/advisories/2014-SV1/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2014-SV2/index.html
+++ b/security/advisories/2014-SV2/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2014-SV3/index.html
+++ b/security/advisories/2014-SV3/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2014-SV4/index.html
+++ b/security/advisories/2014-SV4/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2016-SV1/index.html
+++ b/security/advisories/2016-SV1/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2016-SV2/index.html
+++ b/security/advisories/2016-SV2/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV1/index.html
+++ b/security/advisories/2017-SV1/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV2/index.html
+++ b/security/advisories/2017-SV2/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV3/index.html
+++ b/security/advisories/2017-SV3/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV4/index.html
+++ b/security/advisories/2017-SV4/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV5/index.html
+++ b/security/advisories/2017-SV5/index.html
@@ -8,7 +8,6 @@ redirect_from:
 ---          
                 
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2017-SV6/index.html
+++ b/security/advisories/2017-SV6/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2017-SV6-job-file-link/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2018-SV1/index.html
+++ b/security/advisories/2018-SV1/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2018-SV1-post-password/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2018-SV2/index.html
+++ b/security/advisories/2018-SV2/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2018-SV2-script-name-uuid/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2018-SV3/index.html
+++ b/security/advisories/2018-SV3/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2018-SV3-modify-user-password/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2019-SV1/index.html
+++ b/security/advisories/2019-SV1/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV1-reader-used-files/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2019-SV2/index.html
+++ b/security/advisories/2019-SV2/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV2-group-permissions/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2019-SV3/index.html
+++ b/security/advisories/2019-SV3/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV3-user-privacy/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2019-SV4/index.html
+++ b/security/advisories/2019-SV4/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV4-web-referrer-leakage/
 ---
 <!-- begin SecVul -->
-<hr class="whitespace">
 
 <div class="secvul-row row">
     <div class="small-12 medium-3 columns">

--- a/security/advisories/2019-SV5/index.html
+++ b/security/advisories/2019-SV5/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV5-bypass-filters/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2019-SV6/index.html
+++ b/security/advisories/2019-SV6/index.html
@@ -7,7 +7,6 @@ redirect_from:
   - /security/advisories/2019-SV6-group-owner-context/
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2021-SV1/index.html
+++ b/security/advisories/2021-SV1/index.html
@@ -5,7 +5,6 @@ title: 2021-SV1 User Context
 main-blurb: affects OMERO.web versions prior to 5.9.0
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2021-SV2/index.html
+++ b/security/advisories/2021-SV2/index.html
@@ -5,7 +5,6 @@ title: 2021-SV2 URL validation on login
 main-blurb: affects OMERO.web versions prior to 5.9.0
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2021-SV3/index.html
+++ b/security/advisories/2021-SV3/index.html
@@ -5,7 +5,6 @@ title: 2021-SV3 XSS vectors
 main-blurb: affects OMERO.web versions prior to 5.11.0, OMERO.figure versions prior to 4.4.1
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2021-SV4/index.html
+++ b/security/advisories/2021-SV4/index.html
@@ -5,7 +5,6 @@ title: 2021-SV4 log4j in loci_tools.jar
 main-blurb: affects all versions of the loci_tools.jar library
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2022-22950/index.md
+++ b/security/advisories/2022-22950/index.md
@@ -15,7 +15,7 @@ can say with confidence that OMERO and OMERO Plus are not vulnerable as they do
 not utilize internally or expose programmatic usage of the SpEL API. As already
 documented in the
 [assessment of CVE-2022-22965]({{ site.baseurl }}/2022/04/01/spring-framework-issue.html),
-neither pieces of software parse user input via Spring’s Data Binding
+neither piece of software parse user input via Spring’s Data Binding
 infrastructure.
 
 OME and Glencoe will continue to monitor and evaluate the exposure of our

--- a/security/advisories/2022-22950/index.md
+++ b/security/advisories/2022-22950/index.md
@@ -1,0 +1,22 @@
+---
+layout: security-advisory
+filename: security
+title: CVE-2022-22950 ("Spring Expression DoS Vulnerability")
+---
+
+Major news carriers have been reporting on the
+[Spring Expression DoS Vulnerability](https://spring.io/security/cve-2022-22950/)
+in Java applications that utilize Spring.
+
+
+The OME team in Dundee as well as Glencoe Software have evaluated the libraries
+used by OMERO.server, OMERO.insight as well as the OMERO micro-services. We
+can say with confidence that OMERO and OMERO Plus are not vulnerable as they do
+not utilize internally or expose programmatic usage of the SpEL API. As already
+documented in the
+[assessment of CVE-2022-22965]({{ site.baseurl }}/2022/04/01/spring-framework-issue.html),
+neither pieces of software parse user input via Spring’s Data Binding
+infrastructure.
+
+OME and Glencoe will continue to monitor and evaluate the exposure of our
+various software libraries to these and any other vulnerabilities.

--- a/security/advisories/2023-31047/index.html
+++ b/security/advisories/2023-31047/index.html
@@ -5,7 +5,6 @@ title: CVE-2023-31047 ("Django file upload validation") Assessment
 main-blurb: Affects OMERO.web 5.17.0 - 5.19.0
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/2024-35180/index.html
+++ b/security/advisories/2024-35180/index.html
@@ -5,7 +5,6 @@ title: CVE-2024-35180 ("JSONP callback")
 main-blurb: Affects OMERO.web <=5.25.0
 ---
         <!-- begin SecVul -->
-        <hr class="whitespace">
         <div class="secvul-row row">
             <div class="small-12 medium-3 columns">
                 <h3 class="secvul-heading"><i class="fa fa-th-list"></i> Synopsis</h3>

--- a/security/advisories/index.html
+++ b/security/advisories/index.html
@@ -24,6 +24,11 @@ meta_description: Get the latest on any security advisories for OME products.
                 </thead>
                 <tbody>
                      <tr>
+                        <td>Jan 6, 2025</td>
+                        <td><a href="{{ site.baseurl }}/security/advisories/2022-22950">CVE-2022-22950 ("Spring Expression DoS Vulnerability")</a></td>
+                        <td>N/A</td>
+                    </tr>
+                     <tr>
                         <td>May 21, 2024</td>
                         <td><a href="{{ site.baseurl }}/security/advisories/2024-35180">CVE-2024-35180 ("JSONP callback")</a></td>
                         <td>OMERO.web 5.26.0</td>


### PR DESCRIPTION
Adds an assessment of the impact of https://spring.io/security/cve-2022-22950/ on OMERO.

Unlike the previous Spring assessment which was published as a regular blog (https://www.openmicroscopy.org/2022/04/01/spring-framework-issue.html) but linked from the security advisory page, I tried to make a few layout changes so that this assessment follows the recent advisory schema, is published under https://www.openmicroscopy.org/security/advisories/2022-22950/  and includes a top link back to the table of security advisories.

The `security-advisory` layout was slightly modified to allow a simple text assessment and all the existing advisories were updated to remove the duplicate horizontal line caused by the template layout change. All published advisories should render identically to https://www.openmicroscopy.org/security/advisories/ and the new advisory should be linked from the advisory page.

/cc @chris-allan @kkoz @DavidStirling 