### PR TITLE
Add release announcement for Bio-Formats 8.1.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ defaults:
 future: true
 
 bf:
- version: 8.1.0
+ version: 8.1.1
 
 omero:
  version: 5.6.14

--- a/_posts/2025-03-05-bio-formats-8-1-1.md
+++ b/_posts/2025-03-05-bio-formats-8-1-1.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: Release of Bio-Formats 8.1.1
+intro-blurb: The OME team is pleased to announce the release of Bio-Formats 8.1.1
+---
+
+Today we are releasing Bio-Formats 8.1.1 which includes several fixes and improvements.
+
+The full list of changes included in this release are as follows:
+
+File format fixes:
+
+* Imspector
+    - fix `NumberFormatException` when reading timepoint count
+* InCell
+    - ignore timepoint configurations if a timelapse was not acquired
+    - fix handling of channels with different Z sizes
+    - add `incell.duplicate_missing_planes` option
+* Metamorh
+    - allow files to initialize when channel wavelengths are invalid
+* Nikon ND2
+    - fix pixel type detection for floating point multiposition data
+* ScanR
+    - fix exposure time reporting when field positions are missing
+* Spider
+    - fix type cast warning in image count calculation raised by CodeQL
+
+Bio-Formats improvements:
+
+* Remove unused and obsolete C++ and Javascript files
+* Update GitHub Actions configuration to include CodeQL workflows
+* Add options to `FakeReader` to create test data with instrument and channel wavelength metadata
+* Ensure `getAvailableOptions()` in `IFormatReader` API returns the correct reader options

--- a/_posts/2025-03-05-bio-formats-8-1-1.md
+++ b/_posts/2025-03-05-bio-formats-8-1-1.md
@@ -16,7 +16,7 @@ File format fixes:
     - ignore timepoint configurations if a timelapse was not acquired
     - fix handling of channels with different Z sizes
     - add `incell.duplicate_missing_planes` option
-* Metamorh
+* Metamorph
     - allow files to initialize when channel wavelengths are invalid
 * Nikon ND2
     - fix pixel type detection for floating point multiposition data

--- a/bio-formats/downloads/index.html
+++ b/bio-formats/downloads/index.html
@@ -6,7 +6,7 @@ meta_description: Download the latest version of Bio-Formats here.
         <div class="callout large primary" id="bg-image-bio-formats">
             <div class="row column text-center">
                 <h1>Bio-Formats {{ site.bf.version }} Downloads</h1>
-                <a href="{{ site.baseurl }}/2025/02/05/bio-formats-8-1-0.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
+                <a href="{{ site.baseurl }}/2025/03/05/bio-formats-8-1-1.html" class="large btn-red button sites-button" style="text-shadow: none;">Read the Release Announcement</a>
                 <a href="https://bio-formats.readthedocs.io/en/v{{ site.bf.version }}/" target="_blank" class="hero-link">Read the Docs</a>
             </div>
         </div>

--- a/bio-formats/downloads/index.html
+++ b/bio-formats/downloads/index.html
@@ -23,7 +23,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>Bio-Formats Package</h5>
                         <h6>bioformats_package.jar</h6>
                         <p class="card-caption">The complete bundle for end users containing everything needed to read images into ImageJ. Instructions for installing Bio-Formats in ImageJ are available in the <a href="https://bio-formats.readthedocs.io/en/v{{ site.bf.version }}/users/imagej/installing.html" target="_blank">user guide</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (31.64 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats_package.jar" class="button hollow small"><i class="fa fa-download"></i> Download (43.47 MB)</a>
                     </div>
                 </div>
             </div>
@@ -34,7 +34,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>Command Line Tools</h5>
                         <h6>bftools.zip</h6>
                         <p class="card-caption">A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included. For more info, see the <a href="https://bio-formats.readthedocs.io/en/v{{ site.bf.version }}/users/comlinetools/index.html" target="_blank">command line tools documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.96 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bftools.zip" class="button hollow small"><i class="fa fa-download"></i> Download (41.12 MB)</a>
                     </div>
                 </div>
             </div>
@@ -45,7 +45,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>MATLAB Toolbox</h5>
                         <h6>bfmatlab.zip</h6>
                         <p class="card-caption">A bundle of functions for using Bio-Formats from MATLAB with bioformats_package.jar already included. For more info, see the <a href="https://bio-formats.readthedocs.io/en/v{{ site.bf.version }}/users/matlab/index.html" target="_blank">MATLAB documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (29.97 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bfmatlab.zip" class="button hollow small"><i class="fa fa-download"></i> Download (41.13 MB)</a>
                     </div>
                 </div>
             </div>
@@ -56,7 +56,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>Octave Package</h5>
                         <h6>bioformats-octave-{{ site.bf.version }}.tar.gz</h6>
                         <p class="card-caption">A bundle of functions for using Bio-Formats from Octave. You’ll need to install bioformats_package.jar separately. For more info, see the <a href="https://bio-formats.readthedocs.io/en/v{{ site.bf.version }}/users/octave/index.html" target="_blank">Octave documentation</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-octave-{{ site.bf.version }}.tar.gz" class="button hollow small"><i class="fa fa-download"></i> Download (37.44 KB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-octave-{{ site.bf.version }}.tar.gz" class="button hollow small"><i class="fa fa-download"></i> Download (11.16 KB)</a>
                     </div>
                 </div>
             </div>
@@ -74,7 +74,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>API Documentation</h5>
                         <h6>bio-formats-javadocs-{{ site.bf.version }}.zip</h6>
                         <p class="card-caption">The Javadoc bundle containing the Bio-Formats API documentation is <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/api">here</a>.</p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bio-formats-javadocs-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (14.7 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bio-formats-javadocs-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (5.23 MB)</a>
                     </div>
                 </div>
             </div>
@@ -85,7 +85,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>Source Code</h5>
                         <h6>bioformats-{{ site.bf.version }}.tar.xz</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (9.14 MB)</a>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.tar.xz" class="button hollow small"><i class="fa fa-download"></i> Download (9.63 MB)</a>
                         <a href="https://github.com/openmicroscopy/bioformats" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View GitHub Repository</a>
                     </div>
                 </div>
@@ -97,7 +97,7 @@ meta_description: Download the latest version of Bio-Formats here.
                         <h5>Source Code</h5>
                         <h6>bioformats-{{ site.bf.version }}.zip</h6>
                         <p></p>
-                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (12.67 MB)</a><br>
+                        <a href="https://downloads.openmicroscopy.org/bio-formats/{{ site.bf.version }}/artifacts/bioformats-{{ site.bf.version }}.zip" class="button hollow small"><i class="fa fa-download"></i> Download (11.88 MB)</a><br>
                         <a href="https://github.com/openmicroscopy/bioformats/tree/v{{ site.bf.version }}" target="_blank" class="button hollow small"><i class="fa fa-github"></i> View Git Tag</a>
                     </div>
                 </div>


### PR DESCRIPTION
See https://github.com/ome/bio-formats-documentation/pull/417.

The file sizes on `bio-formats/downloads/index.html` need to be updated before this is merged, but we won't have final sizes until the 8.1.1 tag is pushed and built on Wednesday. This has been proposed as a step in the release process: https://downloads.openmicroscopy.org/bio-formats/8.1.0/artifacts/