### PR TITLE
Add advisories for CVEs 2022-22970 and 2022-22971

### DIFF
--- a/security/advisories/2022-22970/index.md
+++ b/security/advisories/2022-22970/index.md
@@ -1,0 +1,17 @@
+---
+layout: security-advisory
+filename: security
+title: CVE-2022-22970 ("Spring Framework DoS via Data Binding to MultipartFile or Servlet Part")
+---
+
+Major news carriers have been reporting on the
+[Spring Framework DoS Vulnerability](https://spring.io/security/cve-2022-22970/)
+in Java applications that utilize Spring.
+
+The OME team in Dundee as well as Glencoe Software have evaluated the libraries
+used by OMERO.server, OMERO.insight as well as the OMERO micro-services. We
+can say with confidence that OMERO and OMERO Plus are not vulnerable as they do
+not handle file uploads via data binding to MultipartFile or Servlet Part.
+
+OME and Glencoe will continue to monitor and evaluate the exposure of our
+various software libraries to these and any other vulnerabilities.

--- a/security/advisories/2022-22971/index.md
+++ b/security/advisories/2022-22971/index.md
@@ -1,0 +1,17 @@
+---
+layout: security-advisory
+filename: security
+title: CVE-2022-22971 ("Spring Framework DoS with STOMP over WebSocket")
+---
+
+Major news carriers have been reporting on the
+[Spring Framework DoS Vulnerability](https://spring.io/security/cve-2022-22971/)
+in Java applications that utilize Spring.
+
+The OME team in Dundee as well as Glencoe Software have evaluated the libraries
+used by OMERO.server, OMERO.insight as well as the OMERO micro-services. We
+can say with confidence that OMERO and OMERO Plus are not vulnerable as they do
+not use STOMP over WebSocket endpoints.
+
+OME and Glencoe will continue to monitor and evaluate the exposure of our
+various software libraries to these and any other vulnerabilities.

--- a/security/advisories/index.html
+++ b/security/advisories/index.html
@@ -24,6 +24,16 @@ meta_description: Get the latest on any security advisories for OME products.
                 </thead>
                 <tbody>
                      <tr>
+                        <td>September 16, 2025</td>
+                        <td><a href="{{ site.baseurl }}/security/advisories/2022-22971">CVE-2022-22971 ("Spring Framework DoS Vulnerability")</a></td>
+                        <td>N/A</td>
+                    </tr>
+                     <tr>
+                        <td>September 16, 2025</td>
+                        <td><a href="{{ site.baseurl }}/security/advisories/2022-22970">CVE-2022-22970 ("Spring Framework DoS Vulnerability")</a></td>
+                        <td>N/A</td>
+                    </tr>
+                    <tr>
                         <td>August 13, 2025</td>
                         <td><a href="{{ site.baseurl }}/security/advisories/2025-54791">CVE-2025-54791 ("Display of user info on password reset request")</a></td>
                         <td>OMERO.web 5.29.2</td>


### PR DESCRIPTION
See https://spring.io/security/cve-2022-22970/ and https://spring.io/security/cve-2022-22971/

These two vulnerabilities have been flagged by security reporting tools running against the latest version of OMERO.server 5.6.15 but OMERO is unaffected as it is does not rely on either of the functionalities.