### PR TITLE
Update commercial partners page

### DIFF
--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -20,7 +20,6 @@ meta_description: Commercial licenses and deployments of our software are availa
             <div class="row column small-12">
                 <div class="text-center"><img style="max-height: 80px;" alt ="Glencoe Software logo" src="{{ site.baseurl }}/img/logos/glencoe-software.svg"></div>
                 <hr class="invisible">
-                <p>Currently, there is a range of aforementioned activities between the OME project and the commercial entities listed below. If you are interested in becoming a commercial partner, please contact <a href="https://www.glencoesoftware.com/contact/" target="_blank">Glencoe Software</a>.</p>
                 <p>OME's commercial arm, <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software. Inc.</a>, provides commercially licensed, supported and/or customized versions of Bio-Formats and OMERO in addition to performing design and development of these open source software products. Glencoe's <a href="https://www.glencoesoftware.com/products/omeroplus/" target="_blank">OMERO Plus</a> data management platform is deployed in academic, biotech and pharma institutions around the world and is embedded in imaging software solutions from many of the world's leading technology companies. Glencoe has an exclusive commercial license for OMERO from the University of Dundee and for Bio-Formats from the University of Dundee and the University of Wisconsin. For more information, contact the Glencoe team <a href="https://www.glencoesoftware.com/contact/" target="_blank">here</a>.
                 <p>To see a list of organizations using a commercial license of OME software, visit <a href="https://www.glencoesoftware.com/customers/" target="_blank">Glencoe Software's customers page</a>.</p>
                     <div class="medium-6 columns">
@@ -39,7 +38,7 @@ meta_description: Commercial licenses and deployments of our software are availa
             <h3>Ways to Partner with OME</h3>
         </div>
         <hr>
-        <div class="row column small-12"><p>There are a range of activities currently being undertaken by OME in conjunction with the commercial entities listed below. OME has formed partnerships with many of the major commercial imaging hardware and software manufacturers. A partnership can include any of the following:</p>
+        <div class="row column small-12"><p>There are a range of activities currently being undertaken by OME in conjunction with the commercial entities listed below. OME has formed partnerships with many of the major commercial imaging hardware and software manufacturers. If you are interested in becoming a commercial partner, please contact <a href="https://www.glencoesoftware.com/contact/" target="_blank">Glencoe Software</a>. A partnership can include any of the following:</p>
         </div>
         <div class="row">
             <div class="medium-1 medium-offset-1 columns"><i class="icon-fa-red fa fa-comments fa-2x"></i></div>

--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -17,39 +17,18 @@ meta_description: Commercial licenses and deployments of our software are availa
         </div>
         <hr>
         <div class="row">
-            <div class="medium-6 columns">
+            <div class="row column small-12">
                 <div class="text-center"><img style="max-height: 80px;" alt ="Glencoe Software logo" src="{{ site.baseurl }}/img/logos/glencoe-software.svg"></div>
                 <hr class="invisible">
-                <p>Currently, there is a range of aforementioned activities between the OME project and the commercial entities listed below. If you are interested in becoming a commercial partner, please contact <a href="https://www.glencoesoftware.com/contact/" target="_blank">Jason Swedlow</a>, CEO of Glencoe Software.</p>
+                <p>Currently, there is a range of aforementioned activities between the OME project and the commercial entities listed below. If you are interested in becoming a commercial partner, please contact <a href="https://www.glencoesoftware.com/contact/" target="_blank">Glencoe Software</a>.</p>
                 <p>OME's commercial arm, <a href="https://www.glencoesoftware.com" target="_blank">Glencoe Software. Inc.</a>, provides commercially licensed, supported and/or customized versions of Bio-Formats and OMERO in addition to performing design and development of these open source software products. Glencoe's <a href="https://www.glencoesoftware.com/products/omeroplus/" target="_blank">OMERO Plus</a> data management platform is deployed in academic, biotech and pharma institutions around the world and is embedded in imaging software solutions from many of the world's leading technology companies. Glencoe has an exclusive commercial license for OMERO from the University of Dundee and for Bio-Formats from the University of Dundee and the University of Wisconsin. For more information, contact the Glencoe team <a href="https://www.glencoesoftware.com/contact/" target="_blank">here</a>.
+                <p>To see a list of organizations using a commercial license of OME software, visit <a href="https://www.glencoesoftware.com/customers/" target="_blank">Glencoe Software's customers page</a>.</p>
                     <div class="medium-6 columns">
-                    <img src="{{ site.baseurl }}/img/logos/omero.svg" alt="OMERO logo" class="logo-hero" style="max-height: 30px;" />
+                    <img src="{{ site.baseurl }}/img/logos/omero.svg" alt="OMERO logo" class="logo-hero" style="max-height: 40px;" />
                     </div>
                     <div class="medium-6 columns">
-                    <img src="{{ site.baseurl }}/img/logos/omero-plus.svg" alt="OMERO Plus logo" class="logo-hero" style="max-height: 30px;" />
+                    <img src="{{ site.baseurl }}/img/logos/omero-plus.svg" alt="OMERO Plus logo" class="logo-hero" style="max-height: 40px;" />
                     </div>
-            </div>
-            <div class="medium-5 medium-offset-1 columns">
-                <h5>Commercial licenses of OME software</h5>
-                <ul class="dev-ops-links">
-                    <li><a href="https://www.zeiss.com/microscopy/en/home.html" target="_blank">Carl Zeiss Microscopy GmbH</a></li>
-                    <li><a href="http://www.fei.com" target="_blank">FEI, Inc.</a></li>
-                    <li><a href="https://www.imagescience.de/imagic.html" target="_blank">Imagic, GmBH</a></li>
-
-                    <li><a href="https://www.mayachitra.com/" target="_blank">Mayachitra Inc.</a></li>
-                    <li><a href="https://www.perkinelmer.com" target="_blank">PerkinElmer</a></li>
-                    <li><a href="https://www.thermofisher.com/uk/en/home/industrial/electron-microscopy/electron-microscopy-instruments-workflow-solutions/3d-visualization-analysis-software/amira-life-sciences-biomedical.html" target="_blank">Thermo Fisher Scientific</a></li>
-                    <li><a href="https://www.yokogawa.com/solutions/products-platforms/life-science/" target="_blank">Yokogawa</a></li>
-                </ul>
-                <h5>Organizations using a commercial deployment of our software</h5>
-                <ul class="dev-ops-links">
-                    <li><a href="http://www.ascb.org/" target="_blank">American Society of Cell Biology</a></li>
-                    <li><a href="http://hms.harvard.edu/" target="_blank">Harvard Medical School</a></li>
-                    <li><a href="https://www.dundee.ac.uk/locations/national-phenotypic-screening-centre-npsc" target="_blank">National Phenotypic Screening Centre</a></li>
-                    <li><a href="https://www.maastrichtuniversity.nl" target="_blank">Maastricht University</a></li>
-                    <li><a href="http://www.vrtx.com" target="_blank">Vertex</a></li>
-                    <li>...and several others we can't disclose.</li>
-                </ul>
             </div>
         </div>
         <!-- end Commercial Partnerships -->


### PR DESCRIPTION
This aims to update the Commercial Partners page with 2 motivations:
- Update the Glencoe Software contact to not directly reference Jason Swedlow as CEO, given recent [leadership transition](https://www.glencoesoftware.com/pressreleases/2025-09-08-exec-transition.html#topofarticle) at Glencoe.
- List of orgs using a commercial license is out of date.

<img width="964" height="819" alt="Screenshot 2026-04-17 at 1 07 37 PM" src="https://github.com/user-attachments/assets/6f90e851-af48-4747-b969-54c6af4b814b" />

Because Glencoe's customers page is maintained on a regular basis, the strategy used here is to remove the lists on https://www.openmicroscopy.org/commercial-partners/ and instead link to https://www.glencoesoftware.com/customers/.

In removing those lists, the page is a bit distorted if we keep the same layout:
<img width="970" height="784" alt="Screenshot 2026-04-17 at 12 54 56 PM" src="https://github.com/user-attachments/assets/dd54e518-1b5d-406f-a0df-ae47d7b65600" />

I therefore combined the two columns into one:
<img width="953" height="703" alt="Screenshot 2026-04-17 at 12 58 08 PM" src="https://github.com/user-attachments/assets/8d553eb6-ab7c-4b67-9e29-59ed23fc71b5" />

The OMERO and OMERO Plus logos look a bit small now, so I increased their size slightly.

<img width="1001" height="776" alt="Screenshot 2026-04-17 at 1 06 25 PM" src="https://github.com/user-attachments/assets/56be67d3-f018-4ac1-8aa2-1d5c249a488d" />

Open to other strategies to address the outdated customers list and keep this up to date in the future.