### PR TITLE
Added TissueGnostics GmbH

### DIFF
--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -74,7 +74,6 @@ meta_description: Commercial licenses and deployments of our software are availa
         <hr>
         <div id="partnerships" class="row small-up-2 medium-up-2">
             <h5 class="text-center">Organizations supporting OME-TIFF</h5>
-            <div class="column"><a target="_blank" href="https://tissuegnostics.com/"><div class="card-consortium card"><div class="card-section">TissueGnostics GmbH</div></div></a></div>
             <div class="column"><a target="_blank" href="https://bioquant.com"><div class="card-consortium card"><div class="card-section">BIOQUANT Image Analysis Corporation</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.bitplane.com/"><div class="card-consortium card"><div class="card-section">Bitplane AG</div></div></a></div>
             <div class="column"><a target="_blank" href="https://www.zeiss.com/microscopy/en/home.html"><div class="card-consortium card"><div class="card-section">Carl Zeiss Microscopy GmbH</div></div></a></div>
@@ -89,6 +88,7 @@ meta_description: Commercial licenses and deployments of our software are availa
             <div class="column"><a target="_blank" href="http://www.svi.nl/"><div class="card-consortium card"><div class="card-section">Scientific Volume Imaging B.V.</div></div></a></div>
             <div class="column"><a target="_blank" href="https://telight.eu"><div class="card-consortium card"><div class="card-section">Telight</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.fei.com/"><div class="card-consortium card"><div class="card-section">TILL Photonics GmbH, now FEI Munich</div></div></a></div>
+            <div class="column"><a target="_blank" href="https://tissuegnostics.com/"><div class="card-consortium card"><div class="card-section">TissueGnostics GmbH</div></div></a></div>
             <div class="column"><a target="_blank" href="https://www.visiopharm.com/"><div class="card-consortium card"><div class="card-section">Visiopharm</div></div></a></div>
             <hr class="whitespace">
             <div class="row small-up-2 medium-up-2">

--- a/commercial-partners/index.html
+++ b/commercial-partners/index.html
@@ -74,6 +74,7 @@ meta_description: Commercial licenses and deployments of our software are availa
         <hr>
         <div id="partnerships" class="row small-up-2 medium-up-2">
             <h5 class="text-center">Organizations supporting OME-TIFF</h5>
+            <div class="column"><a target="_blank" href="https://tissuegnostics.com/"><div class="card-consortium card"><div class="card-section">TissueGnostics GmbH</div></div></a></div>
             <div class="column"><a target="_blank" href="https://bioquant.com"><div class="card-consortium card"><div class="card-section">BIOQUANT Image Analysis Corporation</div></div></a></div>
             <div class="column"><a target="_blank" href="http://www.bitplane.com/"><div class="card-consortium card"><div class="card-section">Bitplane AG</div></div></a></div>
             <div class="column"><a target="_blank" href="https://www.zeiss.com/microscopy/en/home.html"><div class="card-consortium card"><div class="card-section">Carl Zeiss Microscopy GmbH</div></div></a></div>


### PR DESCRIPTION
Adds TissueGnostics GmbH to the "Organizations supporting OME-TIFF" section of the commercial partners page.

TissueGnostics indicates support for OME-TIFF on the TissueFAXS Imaging Suite page: https://www.tissuegnostics.com/tissuefaxs-platform/tissuefaxs-imaging-suite (under `Open Data Formats` tag), so this change adds them to the existing list with a link to the website.
