### PR TITLE
Fix broken link for OME 2020 speaker

### DIFF
--- a/events/ome-community-meeting-2020/speakers/index.html
+++ b/events/ome-community-meeting-2020/speakers/index.html
@@ -99,7 +99,7 @@ speakers:
     - firstname: Sebastien
       surname: Tosi
       aff: IRB Barcelona
-      link: "https://www.linkedin.com/in/sebastien-tosi/"
+      link: "https://www.irbbarcelona.org/en/research/sebastien-tosi"
     - firstname: Frances
       surname: Wong
       aff: The Open Microscopy Environment


### PR DESCRIPTION
The LinkedIn URL for one of the OME 2020 speakers went 404, replacing it by an institutional URL. There is probably a discussion of whether checking all these historical links is a viable strategy but this is outside the scope of this fix