### PR TITLE
Fix layout of Governace index page

### DIFF
--- a/governance/index.html
+++ b/governance/index.html
@@ -20,8 +20,9 @@ main-blurb: Governance documents for the OME Consortium
 
         <div id="gov-docs" class="row">
             <hr class="whitespace">
-            <div class="small-12 medium-8 medium-offset-2 columns">
-                Governance is organized as a simple hierarchy. At the top, the
+            <div class="row column small-12">
+                <div class="text-left">
+                <p>Governance is organized as a simple hierarchy. At the top, the
                 <a href="participation-agreement/">Participation Agreement</a>
                 defines the overall expectations for collaborators across the
                 community. The OME Management Group (OMG), described by the
@@ -33,18 +34,21 @@ main-blurb: Governance documents for the OME Consortium
                 and ORP Roster, starting from a shared template. This
                 layered approach keeps governance simple at the top while
                 allowing more structure where it is needed in practice.
+                </p>
+                </div>
             </div>
             <hr class="whitespace">
-            <hr class="medium-8">
-        </div>
+            <hr style="width: 100%;">
 {% assign sorted = site.governance %}
 {% for gov in sorted %}
   {% unless gov.name contains "readme" %}
-            <div class="small-12 medium-8 medium-offset-2 columns">
+            <div class="small-12 medium-8 columns">
                 <h2><a href="{{ gov.url | relative_url }}">{{gov.title}}</a></h2>
                 <h6>{{gov.description}}</h6>
                 <div class="row"></div>
             </div>
-            <hr class="medium-8">
+            <hr style="width: 100%;">
   {% endunless %}
 {% endfor %}
+            <hr class="whitespace">
+        </div>


### PR DESCRIPTION
cc @joshmoore 


As discussed, fixing the layout of the governace index page.

Before:

<img width="1550" height="1016" alt="Screenshot 2026-07-01 at 15 23 05" src="https://github.com/user-attachments/assets/b0b126d1-aaa7-4431-805f-f9cc164ea78f" />


With this PR

<img width="1714" height="1136" alt="Screenshot 2026-07-01 at 15 23 14" src="https://github.com/user-attachments/assets/c0269774-c3bd-4fbe-bccc-89f6d4f7d9c1" />
