### PR TITLE
Submodule init info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ All content is released under
 
 ## Building
 
+First make sure you have submodules (governance pages) checked out:
+
+    $ git submodule init
+    $ git submodule update
+
 You can build and serve the pages using Jekyll and Docker with:
 
     $ ./docker_startup.sh

--- a/about/index.html
+++ b/about/index.html
@@ -78,7 +78,6 @@ partnerships2:
                 <ul class="vertical medium-horizontal dropdown menu-subnav menu expanded small-12 columns" data-responsive-menu="accordion medium-dropdown">
                     <li><a href="#goals">Project Goals</a></li>
                     <li><a href="#funding">Funding</a></li>
-                    <li><a href="#consortium">The OME Consortium</a></li>
                     <li><a href="#standards">Community Standards</a></li>
                 </ul>
             </div>

--- a/css/openmicroscopy.css
+++ b/css/openmicroscopy.css
@@ -282,6 +282,7 @@ h3.subdivider {
     font-weight: 500;
     text-rendering: optimizeLegibility;
     text-transform: uppercase;
+    text-align: center;
 }
 
 .menu-subnav li a:hover, .menu-subnav li a.is-active {


### PR DESCRIPTION
Adds `git submodle` commands to the build instructions on the README.

Also removes the `CONSORTIUM` link in the top of the `about` page, since it did nothing.

This highlighted the fact that those menu links are not aligned very well. They look better with 'center' alignment. Fixed in 3rd commit.
To test, look at about page.

Screenshot shows *with* the last commit (top) and *without* the last commit (bottom) where the links are too far to the left:

<img width="1638" height="914" alt="Screenshot 2026-07-02 at 11 53 07" src="https://github.com/user-attachments/assets/9c66b581-d7b2-43fd-b557-fd009a4ae794" />


cc @pwalczysko 