### PR TITLE
Fix links

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -438,7 +438,7 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
             <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> September 19 & 21, 2018</h6>
-                <h2><a href="http://www.eurobioimaging.eu/content-page/international-training-courses-core-facility-staff">OMERO and IDR Workshops, Sydney</a></h2>
+                <h2><a href="https://downloads.openmicroscopy.org/presentations/2018/GBI-Sydney/">OMERO and IDR Workshops, Sydney</a></h2>
                 <p class="card-caption">GBI training: two 1h15 workshops on Data Management with OMERO and Public image data resources.</p>
             </div>
             <hr class="medium-8">

--- a/events/index.html
+++ b/events/index.html
@@ -457,7 +457,7 @@ meta_description: Learn how to use OMERO by attending one of our workshops.
             <hr class="medium-8">
             <div class="small-12 medium-8 medium-offset-2 columns">
                 <h6><i class="fa fa-calendar"></i> June 5-8, 2018</h6>
-                <h2><a href="http://www.elmi2018.eu/">OMERO Workshop, Dublin</a></h2>
+                <h2><a href="https://downloads.openmicroscopy.org/presentations/2018/ELMI-Dublin/">OMERO Workshop, Dublin</a></h2>
                 <p class="card-caption">ELMI: Two 1-hour workshops about the OMERO ecosystem.</p>
             </div>
             <hr class="medium-8">


### PR DESCRIPTION
Fixes 2 links in Events to older workshop events whose sites have been deprecated in the meantime.
These 2 old links were also http.

Replacing with links to the presentations of those 2 workshops on our downloads.op...py.org pages.