### PR TITLE
Add repositories.yml file

### DIFF
--- a/repositories.yml
+++ b/repositories.yml
@@ -1,0 +1,3 @@
+submodules:
+  _governance:
+    base-branch: main


### PR DESCRIPTION
Trying to add a ``repository.yml`` file to circumvent the problem in https://github.com/ome/governance/issues/4#issuecomment-5037409641


NB: This fix works well with Jenkins, as seen on the inclusion of the PR nr3 in ome/governance in https://snoopycrimecop.github.io/www.openmicroscopy.org/governance/. 

see also the inclusion of the PR in as shown below https://merge-ci.openmicroscopy.org/jenkins/job/WEBSITE-push/37/console 

```
Repository: ome/governance
Already up to date.

Merged PRs:
  - PR 3 melissalinkert 'Bio-Formats ORP charter and roster'
 ```
